### PR TITLE
Harden KotorPatcher: DETOUR <5 underflow, wrapper buffer sizing, dead overflow guard

### DIFF
--- a/src/KotorPatcher/src/config_reader.cpp
+++ b/src/KotorPatcher/src/config_reader.cpp
@@ -233,6 +233,14 @@ namespace KotorPatcher {
                         continue;
                     }
 
+                    // DETOUR hooks overwrite a 5-byte JMP at the hook address and NOP the
+                    // remaining stolen bytes; fewer than 5 original_bytes makes the
+                    // (size - 5) NOP-count underflow in ApplyPatch. Reject early (mirrors REPLACE).
+                    if (patch.type == HookType::DETOUR && patch.originalBytes.size() < 5) {
+                        OutputDebugStringA("[Config] DETOUR hook original_bytes must be at least 5 bytes (for JMP instruction)\n");
+                        continue;
+                    }
+
                     // original_bytes are used for both verification and execution in wrapper
                     // No separate stolen_bytes field needed
 

--- a/src/KotorPatcher/src/patcher.cpp
+++ b/src/KotorPatcher/src/patcher.cpp
@@ -223,10 +223,12 @@ namespace KotorPatcher {
             return false;
         }
 
-        // Clear out the remaining bytes with NOPs
-        if (!Trampoline::WriteNoOps(patch.hookAddress + 5, patch.originalBytes.size() - 5)) {
-            OutputDebugStringA("[KotorPatcher] Failed to write No-Ops after trampoline\n");
-            return false;
+        // Clear out the remaining bytes with NOPs (only if there are stolen bytes beyond the 5-byte JMP)
+        if (patch.originalBytes.size() > 5) {
+            if (!Trampoline::WriteNoOps(patch.hookAddress + 5, patch.originalBytes.size() - 5)) {
+                OutputDebugStringA("[KotorPatcher] Failed to write No-Ops after trampoline\n");
+                return false;
+            }
         }
 
 

--- a/src/KotorPatcher/src/trampoline.cpp
+++ b/src/KotorPatcher/src/trampoline.cpp
@@ -54,7 +54,8 @@ namespace KotorPatcher {
                 return true;
             }
             // Prevent 32-bit wrap/overflow for the DWORD + length calculation
-            DWORD endAddr64 = static_cast<DWORD>(startAddress) + static_cast<DWORD>(length);
+            // Compute in 64-bit so the comparison is meaningful (a DWORD can never exceed 0xFFFFFFFF).
+            unsigned long long endAddr64 = static_cast<unsigned long long>(startAddress) + static_cast<unsigned long long>(length);
             if (endAddr64 > 0xFFFFFFFFULL) {
                 OutputDebugStringA("[Trampoline] WriteNoOps: requested range overflows 32-bit address space\n");
                 return false;

--- a/src/KotorPatcher/src/wrappers/wrapper_x86_win32.cpp
+++ b/src/KotorPatcher/src/wrappers/wrapper_x86_win32.cpp
@@ -60,9 +60,17 @@ namespace KotorPatcher {
         }
 
         void* WrapperGenerator_x86_Win32::GenerateDetourWrapper(const WrapperConfig& config) {
-            // Estimate wrapper size
-            // Base: ~100 bytes, +10 per excluded register
-            size_t estimatedSize = 128 + (config.excludeFromRestore.size() * 10);
+            // Estimate wrapper size (sound upper bound)
+            // Fixed sections worst case (prologue PUSHAD/PUSHFD + MOV EBX,ESP + CALL rel32 +
+            // ADD ESP,imm32 cleanup + MOV ESP,EBX + POPFD + selective restore of all 8
+            // registers + JMP rel32) fits well under the 96-byte constant. Each parameter
+            // emits at most 8 bytes (LEA ECX,[ESP+imm32] = 7 + PUSH ECX = 1). The original
+            // bytes are emitted verbatim when !skipOriginalBytes. Selective register restore
+            // emits up to 3 bytes per excluded register on top of the fixed budget.
+            size_t estimatedSize = 96
+                + config.parameters.size() * 8
+                + config.originalBytes.size()
+                + config.excludeFromRestore.size() * 3;
 
             BYTE* wrapperMem = static_cast<BYTE*>(AllocateExecutableMemory(estimatedSize));
             if (!wrapperMem) {


### PR DESCRIPTION
## Three hardening fixes for KotorPatcher (runtime injector)

Verified against source, adversarially reviewed, and **compiles clean** (KotorPatcher.vcxproj, Release|Win32, MSVC v143 — only the pre-existing C4477 warning remains). No behaviour change for valid, in-spec patches; each closes a crash/correctness gap reachable from a hand-authored `patch_config.toml` (which the DLL parses directly, independent of the C# launcher's validation).

### 1. DETOUR hooks: reject `<5` original_bytes (size_t underflow)
REPLACE already rejects `original_bytes < 5`; DETOUR didn't. `ApplyPatch`'s DETOUR path calls `WriteNoOps(hookAddress + 5, originalBytes.size() - 5)` with no guard, so `<5` bytes underflows `size_t` to ~4 GB and crashes on patch init. Added the guard in `config_reader.cpp` and mirrored the REPLACE `size() > 5` guard in `patcher.cpp`.

### 2. Detour-wrapper buffer size estimate was unsound
`GenerateDetourWrapper` sized its executable buffer as `128 + excludeFromRestore.size()*10`, omitting per-parameter emission (up to 8 bytes each) and the verbatim `original_bytes` copy — a latent exec-buffer overflow. No bundled patch triggers it today (largest emitted wrapper ~65 B), but the bound is unsound. Replaced with `96 + params*8 + originalBytes + excludes*3`.

### 3. Dead overflow guard in WriteNoOps
`endAddr64` was a `DWORD`, so `startAddress + length` wrapped mod 2^32 before the `> 0xFFFFFFFFULL` check — unreachable dead code. Widened to 64-bit.

3 commits, 4 files (`config_reader.cpp`, `patcher.cpp`, `wrappers/wrapper_x86_win32.cpp`, `trampoline.cpp`).
