### PR TITLE
Safe-guards for scenarios when the patch manager shares a directory with target game

### DIFF
--- a/src/KPatchCore/Applicators/PatchApplicator.cs
+++ b/src/KPatchCore/Applicators/PatchApplicator.cs
@@ -534,6 +534,7 @@ public class PatchApplicator
             messages.Add("Step 7/8: Installing patcher DLL and dependencies...");
 
             // Copy KotorPatcher.dll to game directory if path provided
+            var destPath = Path.Combine(gameDir, "KotorPatcher.dll");
             if (!string.IsNullOrEmpty(options.PatcherDllPath))
             {
                 if (!File.Exists(options.PatcherDllPath))
@@ -548,24 +549,62 @@ public class PatchApplicator
                     };
                 }
 
-                var destPath = Path.Combine(gameDir, "KotorPatcher.dll");
-                File.Copy(options.PatcherDllPath, destPath, overwrite: true);
-                messages.Add($"  ✓ Copied KotorPatcher.dll to game directory");
+                // If DLL already present, skip copy step
+                if (PathHelpers.SamePath(options.PatcherDllPath, destPath))
+                {
+                    messages.Add($"  ✓ KotorPatcher.dll already in place (Patch Manager runs from the game directory)");
+                }
+                else
+                {
+                    try
+                    {
+                        File.Copy(options.PatcherDllPath, destPath, overwrite: true);
+                    }
+                    catch (Exception ex)
+                    {
+                        if (backup != null)
+                        {
+                            BackupManager.RestoreBackup(backup);
+                        }
+
+                        return new InstallResult
+                        {
+                            Success = false,
+                            Error = $"Failed to copy KotorPatcher.dll to game directory: {ex.Message}",
+                            DetectedVersion = gameVersion,
+                            Backup = backup,
+                            Messages = messages
+                        };
+                    }
+
+                    messages.Add($"  ✓ Copied KotorPatcher.dll to game directory");
+                }
 
                 // Copy sqlite3.dll (should be in same directory as KotorPatcher.dll)
                 var patcherDir = Path.GetDirectoryName(options.PatcherDllPath);
                 if (patcherDir != null)
                 {
                     var sqliteDllSource = Path.Combine(patcherDir, "sqlite3.dll");
-                    if (File.Exists(sqliteDllSource))
+                    var sqliteDllDest = Path.Combine(gameDir, "sqlite3.dll");
+                    if (!File.Exists(sqliteDllSource))
                     {
-                        var sqliteDllDest = Path.Combine(gameDir, "sqlite3.dll");
-                        File.Copy(sqliteDllSource, sqliteDllDest, overwrite: true);
-                        messages.Add($"  ✓ Copied sqlite3.dll to game directory");
+                        messages.Add($"  ⚠️ Warning: sqlite3.dll not found at: {sqliteDllSource}");
+                    }
+                    else if (PathHelpers.SamePath(sqliteDllSource, sqliteDllDest))
+                    {
+                        messages.Add($"  ✓ sqlite3.dll already in place (Patch Manager runs from the game directory)");
                     }
                     else
                     {
-                        messages.Add($"  ⚠️ Warning: sqlite3.dll not found at: {sqliteDllSource}");
+                        try
+                        {
+                            File.Copy(sqliteDllSource, sqliteDllDest, overwrite: true);
+                            messages.Add($"  ✓ Copied sqlite3.dll to game directory");
+                        }
+                        catch (Exception ex)
+                        {
+                            messages.Add($"  ⚠️ Warning: failed to copy sqlite3.dll: {ex.Message}");
+                        }
                     }
                 }
             }
@@ -573,6 +612,24 @@ public class PatchApplicator
             {
                 messages.Add($"  ⚠️ Warning: KotorPatcher.dll path not provided");
                 messages.Add($"  ⚠️ Make sure KotorPatcher.dll and sqlite3.dll are in game directory");
+            }
+
+            // Fail loudly if the DLL never made it to the destination
+            if (!File.Exists(destPath))
+            {
+                if (backup != null)
+                {
+                    BackupManager.RestoreBackup(backup);
+                }
+
+                return new InstallResult
+                {
+                    Success = false,
+                    Error = "KotorPatcher.dll is missing from the game directory after installation.",
+                    DetectedVersion = gameVersion,
+                    Backup = backup,
+                    Messages = messages
+                };
             }
 
             var stateResult = InstallStateManager.SaveOrUpdate(

--- a/src/KPatchCore/Applicators/PatchRemover.cs
+++ b/src/KPatchCore/Applicators/PatchRemover.cs
@@ -182,9 +182,25 @@ public static class PatchRemover
                 filesToRemove.Add(InstallStateManager.StateFileName);
             }
 
+            var appDir = AppContext.BaseDirectory;
+            var managerOwnedFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "KotorPatcher.dll",
+                "KPatchLauncher.exe"
+            };
+
             // Remove each file using safe delete helper
             foreach (var fileName in filesToRemove)
             {
+                if (managerOwnedFiles.Contains(fileName) &&
+                    PathHelpers.SamePath(
+                        Path.Combine(gameDir, fileName),
+                        Path.Combine(appDir, fileName)))
+                {
+                    messages.Add($"  Preserved {fileName} (Patch Manager runs from the game directory)");
+                    continue;
+                }
+
                 SafeDeleteFile(gameDir, fileName, removedFiles, messages);
             }
 

--- a/src/KPatchCore/Common/PathHelpers.cs
+++ b/src/KPatchCore/Common/PathHelpers.cs
@@ -67,6 +67,25 @@ public static class PathHelpers
     }
 
     /// <summary>
+    /// Determines whether two paths refer to the same file/directory location.
+    /// Comparison is done on the fully-resolved paths, is case-insensitive
+    /// (matching Windows and Wine filesystem semantics), and ignores a trailing
+    /// directory separator. This is a path-string comparison, not a
+    /// hardlink/symlink identity check.
+    /// Returns false if either path is null or empty.
+    /// </summary>
+    public static bool SamePath(string? a, string? b)
+    {
+        if (string.IsNullOrEmpty(a) || string.IsNullOrEmpty(b))
+            return false;
+
+        static string Normalize(string p) =>
+            Path.TrimEndingDirectorySeparator(Path.GetFullPath(p));
+
+        return string.Equals(Normalize(a), Normalize(b), StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
     /// Converts an absolute path to a relative path from a base directory
     /// </summary>
     public static string GetRelativePath(string basePath, string targetPath)


### PR DESCRIPTION
- Skips DLL copy step if the file already exists in the destination
- Safer sqlite copy
- prevent deletion of DLL and EXE on uninstall if the directory is shared
- helper function for case insensitive path comparisons (this can help Wine)