### PR TITLE
Fix selective-POPAD ESP-slot handling in the x86 detour wrapper

### DIFF
--- a/src/KotorPatcher/src/wrappers/wrapper_x86_win32.cpp
+++ b/src/KotorPatcher/src/wrappers/wrapper_x86_win32.cpp
@@ -179,15 +179,32 @@ namespace KotorPatcher {
                     // We need to manually pop each register
                     const char* regOrder[] = { "edi", "esi", "ebp", "esp", "ebx", "edx", "ecx", "eax" };
                     const BYTE popOpcodes[] = { 0x5F, 0x5E, 0x5D, 0x5C, 0x5B, 0x5A, 0x59, 0x58 };
+                    constexpr int kEspSlot = 3;
 
                     for (int i = 0; i < 8; i++) {
-                        if (config.ShouldRestoreRegister(regOrder[i])) {
+                        // Hardware POPAD never restores ESP — it just advances
+                        // past the saved-ESP slot. Emitting `POP ESP` (0x5C)
+                        // here would write ESP from the saved value, jumping
+                        // past the remaining EBX/EDX/ECX/EAX slots and reading
+                        // them from random stack memory. Always skip the ESP
+                        // slot regardless of exclude_from_restore.
+                        if (i != kEspSlot && config.ShouldRestoreRegister(regOrder[i])) {
                             EmitByte(code, popOpcodes[i]);  // POP reg
                         } else {
-                            // Skip this register (pop to nowhere)
-                            EmitByte(code, 0x83);  // ADD ESP, 4
-                            EmitByte(code, 0xC4);
-                            EmitByte(code, 0x04);
+                            // Skip this register (matches POPAD's ESP semantics
+                            // for the ESP slot, or honors the user's exclusion
+                            // for other slots).
+                            //
+                            // Use LEA ESP, [ESP+4] instead of ADD ESP, 4: ADD
+                            // sets EFLAGS (ZF/SF/CF/OF) from the result, which
+                            // would clobber flag state the restored context or
+                            // downstream target code depends on. LEA is the
+                            // standard flag-preserving stack adjustment.
+                            // 4 bytes vs 3 — a minor size cost for correctness.
+                            EmitByte(code, 0x8D);  // LEA r32, m
+                            EmitByte(code, 0x64);  // ModRM: ESP, [ESP+disp8] (SIB follows)
+                            EmitByte(code, 0x24);  // SIB: [ESP]
+                            EmitByte(code, 0x04);  // disp8 = 4
                         }
                     }
                 }


### PR DESCRIPTION
Two bugs in the manual register-restore loop the wrapper uses when a detour hook sets a non-empty `exclude_from_restore` (the path taken instead of `POPAD`):

**1. `POP ESP` corrupts the restore.** The loop emits `POP ESP` (`0x5C`) for the ESP slot, which overwrites ESP with the saved value; the following pops then read from the wrong stack location and hand garbage to the remaining registers. Hardware `POPAD` *skips* the ESP slot (advances without writing) — the manual loop must do the same, regardless of the exclude list.

**2. `ADD ESP,4` clobbers EFLAGS.** Skipped slots used `ADD ESP,4`, which sets ZF/SF/CF/OF. That silently corrupts flag state the restored context or downstream target code may depend on. `LEA ESP,[ESP+4]` has the identical effect on ESP with no flag side-effects (4 bytes vs 3).

The selective-restore path isn't exercised by any shipping patch today, so this is a latent fix — but it's a prerequisite for any hook that needs a register (e.g. a return value) to survive the wrapper.

---
*Disclaimer: this is well-tested on my side — it ships in a downstream accessibility mod for KOTOR 1 built on your patcher, and users run it without reported problems. That said, I use AI assistance to write this code, so it's entirely possible some of it is redundant or based on a misunderstanding of your codebase. Please review critically; I'm happy to adjust or drop anything.*
