### PR TITLE
Add consumed_exit_address: conditional consumed-event exit for detour hooks

### DIFF
--- a/src/KPatchCore/Applicators/ConfigGenerator.cs
+++ b/src/KPatchCore/Applicators/ConfigGenerator.cs
@@ -125,6 +125,13 @@ public static class ConfigGenerator
                         hookTable["skip_original_bytes"] = true;
                     }
 
+                    // Add consumed_exit_address only when set — keeps existing
+                    // hooks unaffected and the runtime treats absence as "feature off".
+                    if (hook.ConsumedExitAddress.HasValue)
+                    {
+                        hookTable["consumed_exit_address"] = (long)hook.ConsumedExitAddress.Value;
+                    }
+
                     // Add parameters if any (for INLINE hooks)
                     if (hook.Parameters.Count > 0)
                     {

--- a/src/KPatchCore/Models/Hook.cs
+++ b/src/KPatchCore/Models/Hook.cs
@@ -95,6 +95,18 @@ public sealed class Hook
     public bool SkipOriginalBytes { get; init; } = false;
 
     /// <summary>
+    /// When set, the wrapper jumps to this address (instead of resuming at the
+    /// natural fall-through point — the hook address plus the original bytes'
+    /// length) whenever the handler returns a non-zero int. Lets a hook
+    /// selectively consume events at runtime.
+    /// Caller must include "eax" in <see cref="ExcludeFromRestore"/> so the
+    /// handler's return value survives the wrapper. Stack state at the target
+    /// must match stack state at the natural fall-through point.
+    /// Default: null (feature disabled — wrapper always uses fall-through path).
+    /// </summary>
+    public uint? ConsumedExitAddress { get; init; }
+
+    /// <summary>
     /// Validates that the hook configuration is valid
     /// </summary>
     public bool IsValid(out string? error)

--- a/src/KPatchCore/Models/Hook.cs
+++ b/src/KPatchCore/Models/Hook.cs
@@ -147,6 +147,19 @@ public sealed class Hook
                     return false;
                 }
             }
+
+            // consumed_exit_address reads the handler's return value from EAX
+            // (the wrapper's consume check is TEST EAX,EAX). If EAX isn't
+            // excluded from restore, the wrapper restores it before that check
+            // and the consume decision runs on a stale value. Enforce the
+            // pairing so this can't silently misbehave at runtime.
+            if (ConsumedExitAddress is > 0 &&
+                !ExcludeFromRestore.Exists(r => string.Equals(r, "eax", StringComparison.OrdinalIgnoreCase)))
+            {
+                error = "consumed_exit_address requires \"eax\" in exclude_from_restore " +
+                        "(the handler's return value is read from EAX by the wrapper's consume check)";
+                return false;
+            }
         }
         else if (Type == HookType.Simple)
         {

--- a/src/KPatchCore/Parsers/HooksParser.cs
+++ b/src/KPatchCore/Parsers/HooksParser.cs
@@ -144,6 +144,12 @@ public static class HooksParser
                 var excludeFromRestore = TryGetStringArray(hookTable, "exclude_from_restore") ?? new List<string>();
                 var skipOriginalBytes = TryGetBool(hookTable, "skip_original_bytes") ?? false;
 
+                uint? consumedExitAddress = null;
+                if (TryGetUInt(hookTable, "consumed_exit_address", out var consumedExit) && consumedExit != 0)
+                {
+                    consumedExitAddress = consumedExit;
+                }
+
                 // Parse parameters (optional, for Detour hooks)
                 var parametersResult = ParseParameters(hookTable, i);
                 if (!parametersResult.Success)
@@ -163,6 +169,7 @@ public static class HooksParser
                     PreserveFlags = preserveFlags,
                     ExcludeFromRestore = excludeFromRestore,
                     SkipOriginalBytes = skipOriginalBytes,
+                    ConsumedExitAddress = consumedExitAddress,
                     Parameters = parameters
                 };
 

--- a/src/KotorPatcher/include/patcher.h
+++ b/src/KotorPatcher/include/patcher.h
@@ -67,6 +67,13 @@ namespace KotorPatcher {
         // Set to true when fully replacing behavior instead of augmenting it
         bool skipOriginalBytes = false;
 
+        // When non-zero, the wrapper jumps to this address (instead of resuming
+        // at hookAddress + originalBytes.size()) whenever the handler returns
+        // a non-zero int. Lets a hook selectively consume engine events.
+        // Caller must include "eax" in excludeFromRestore so the handler's
+        // return value survives the wrapper. Default 0 = feature disabled.
+        DWORD consumedExitAddress = 0;
+
         // Original function pointer (future: for detour trampolines)
         void* originalFunction = nullptr;
 

--- a/src/KotorPatcher/include/wrappers/wrapper_base.h
+++ b/src/KotorPatcher/include/wrappers/wrapper_base.h
@@ -45,6 +45,14 @@ namespace KotorPatcher {
             // instead of augmenting it
             bool skipOriginalBytes = false;
 
+            // When non-zero, the wrapper emits a conditional jump after the
+            // register-restore epilogue: if the handler returned non-zero in
+            // EAX, control transfers to this address; otherwise the wrapper
+            // falls through to the existing original-bytes / skipOriginalBytes
+            // path. Caller must add "eax" to excludeFromRestore so the
+            // handler's return value reaches the test. Default 0 = disabled.
+            DWORD consumedExitAddress = 0;
+
             // Original function pointer (future use)
             void* originalFunction = nullptr;
 

--- a/src/KotorPatcher/src/config_reader.cpp
+++ b/src/KotorPatcher/src/config_reader.cpp
@@ -311,6 +311,27 @@ namespace KotorPatcher {
                         OutputDebugStringA(debugMsg);
                     }
 
+                    // === Parse Consumed Exit Address (Optional) ===
+                    // Mirrors the hook 'address' field: accept a hex string
+                    // "0x401234" or an integer (ConfigGenerator emits an integer).
+                    auto consumedExitStr = hookTable->at_path("consumed_exit_address").value<std::string>();
+                    auto consumedExitInt = hookTable->at_path("consumed_exit_address").value<int64_t>();
+
+                    if (consumedExitStr) {
+                        if (!ParseHexAddress(*consumedExitStr, patch.consumedExitAddress)) {
+                            OutputDebugStringA(("[Config] Invalid consumed_exit_address: " + *consumedExitStr + "\n").c_str());
+                        }
+                    }
+                    else if (consumedExitInt) {
+                        patch.consumedExitAddress = static_cast<DWORD>(*consumedExitInt);
+                    }
+                    if (patch.consumedExitAddress != 0) {
+                        char debugMsg[256];
+                        sprintf_s(debugMsg, "[Config] Parsed consumed_exit_address = 0x%08X for hook at 0x%08X\n",
+                            patch.consumedExitAddress, patch.hookAddress);
+                        OutputDebugStringA(debugMsg);
+                    }
+
                     // Parse parameters (optional, for DETOUR hooks)
                     auto parametersArray = hookTable->at_path("parameters").as_array();
                     if (parametersArray) {

--- a/src/KotorPatcher/src/patcher.cpp
+++ b/src/KotorPatcher/src/patcher.cpp
@@ -265,6 +265,7 @@ namespace KotorPatcher {
         wrapperConfig.preserveFlags = patch.preserveFlags;
         wrapperConfig.excludeFromRestore = patch.excludeFromRestore;
         wrapperConfig.skipOriginalBytes = patch.skipOriginalBytes;
+        wrapperConfig.consumedExitAddress = patch.consumedExitAddress;
         wrapperConfig.originalFunction = patch.originalFunction;
 
         char skipMsg[128];

--- a/src/KotorPatcher/src/wrappers/wrapper_x86_win32.cpp
+++ b/src/KotorPatcher/src/wrappers/wrapper_x86_win32.cpp
@@ -61,8 +61,11 @@ namespace KotorPatcher {
 
         void* WrapperGenerator_x86_Win32::GenerateDetourWrapper(const WrapperConfig& config) {
             // Estimate wrapper size
-            // Base: ~100 bytes, +10 per excluded register
+            // Base: ~100 bytes, +10 per excluded register, +10 for consumed-exit conditional jump
             size_t estimatedSize = 128 + (config.excludeFromRestore.size() * 10);
+            if (config.consumedExitAddress != 0) {
+                estimatedSize += 16;
+            }
 
             BYTE* wrapperMem = static_cast<BYTE*>(AllocateExecutableMemory(estimatedSize));
             if (!wrapperMem) {
@@ -210,40 +213,77 @@ namespace KotorPatcher {
                 }
             }
 
-            // ===== RETURN TO ORIGINAL CODE =====
-
-            if (config.skipOriginalBytes) {
-                // Skip executing original bytes - jump directly back to continue execution
-                // This is used when fully replacing behavior rather than augmenting it
-                void* returnAddress = reinterpret_cast<void*>(
-                    config.hookAddress + static_cast<DWORD>(config.originalBytes.size())
-                );
-                EmitByte(code, 0xE9);  // JMP rel32
-                DWORD returnOffset = CalculateRelativeOffset(code - 1, returnAddress);
-                EmitDword(code, returnOffset);
-
-                char debugMsg[256];
-                sprintf_s(debugMsg, "[Wrapper] Skipping original bytes, jumping directly to 0x%08X\n",
-                    reinterpret_cast<DWORD>(returnAddress));
-                OutputDebugStringA(debugMsg);
-            } else {
-                // Execute the original bytes (instructions we overwrote with JMP)
-                // These were specified in the patch config to align with instruction boundaries
+            // ===== EXECUTE STOLEN ORIGINAL BYTES =====
+            // Run the original instructions BEFORE the conditional consumed-exit
+            // jump so both paths leave the stack and registers in the same state
+            // — equivalent to the cut bytes having executed natively in-place.
+            // The consumed_exit_address contract assumes this state, since the
+            // caller chose the target by inspecting where execution would
+            // naturally land *after* the cut.
+            if (!config.skipOriginalBytes) {
                 if (config.originalBytes.empty()) {
                     OutputDebugStringA("[Wrapper] ERROR: No original bytes provided for DETOUR hook\n");
                     return nullptr;
                 }
-
-                // Emit the original bytes to execute the overwritten instructions
                 EmitBytes(code, config.originalBytes.data(), config.originalBytes.size());
+            }
 
-                // Jump back to hookAddress + original_bytes_size to continue normal execution
+            // ===== CONDITIONAL CONSUMED-EVENT EXIT =====
+            // If the hook config specifies a consumed_exit_address, emit:
+            //   PUSHFD                    ; preserve cut-bytes' EFLAGS state
+            //   TEST EAX, EAX             ; clobbers ZF/SF/PF/CF/OF
+            //   JZ +6                     ; skip POPFD + JMP rel32, fall through
+            //   POPFD                     ; consumed path: restore EFLAGS
+            //   JMP rel32 consumed_exit   ; handler returned non-zero -> consumed
+            //   POPFD                     ; fall-through path: restore EFLAGS
+            //
+            // PUSHFD/POPFD wraps the TEST so that the cut bytes' flag state
+            // (e.g. a CMP whose ZF the target's downstream Jcc reads) survives
+            // through to the natural-resume JMP. Without it, a hook whose cut
+            // ends in or directly precedes a flag-consuming Jcc would be
+            // silently misrouted, since TEST EAX,EAX overwrites those flags.
+            //
+            // Caller is responsible for excluding "eax" from POPAD restoration
+            // so the handler's return value reaches the TEST.
+            if (config.consumedExitAddress != 0) {
+                EmitByte(code, 0x9C);  // PUSHFD — save cut bytes' EFLAGS
+                EmitByte(code, 0x85);  // TEST r/m32, r32
+                EmitByte(code, 0xC0);  // ModRM: EAX, EAX
+                EmitByte(code, 0x74);  // JZ rel8
+                EmitByte(code, 0x06);  // skip POPFD (1) + JMP rel32 (5) = 6 bytes
+                EmitByte(code, 0x9D);  // POPFD — restore EFLAGS for consumed path
+                EmitByte(code, 0xE9);  // JMP rel32
+                DWORD consumedOffset = CalculateRelativeOffset(
+                    code - 1,
+                    reinterpret_cast<void*>(config.consumedExitAddress));
+                EmitDword(code, consumedOffset);
+                EmitByte(code, 0x9D);  // POPFD — restore EFLAGS for fall-through
+
+                char debugMsg[256];
+                sprintf_s(debugMsg, "[Wrapper] Conditional consumed-exit -> 0x%08X emitted\n",
+                    config.consumedExitAddress);
+                OutputDebugStringA(debugMsg);
+            }
+
+            // ===== JUMP BACK TO NATURAL FALL-THROUGH =====
+            // hookAddress + originalBytes.size() is the resume point for the
+            // non-consumed path. With cut bytes already emitted above, the
+            // stack/register state at the target matches what the engine would
+            // see after natively executing the cut at the hook site.
+            {
                 void* returnAddress = reinterpret_cast<void*>(
                     config.hookAddress + static_cast<DWORD>(config.originalBytes.size())
                 );
                 EmitByte(code, 0xE9);  // JMP rel32
                 DWORD returnOffset = CalculateRelativeOffset(code - 1, returnAddress);
                 EmitDword(code, returnOffset);
+
+                if (config.skipOriginalBytes) {
+                    char debugMsg[256];
+                    sprintf_s(debugMsg, "[Wrapper] Skipping original bytes, jumping directly to 0x%08X\n",
+                        reinterpret_cast<DWORD>(returnAddress));
+                    OutputDebugStringA(debugMsg);
+                }
             }
 
             // Flush instruction cache

--- a/src/KotorPatcher/src/wrappers/wrapper_x86_win32.cpp
+++ b/src/KotorPatcher/src/wrappers/wrapper_x86_win32.cpp
@@ -61,7 +61,8 @@ namespace KotorPatcher {
 
         void* WrapperGenerator_x86_Win32::GenerateDetourWrapper(const WrapperConfig& config) {
             // Estimate wrapper size
-            // Base: ~100 bytes, +10 per excluded register, +10 for consumed-exit conditional jump
+            // Base: ~100 bytes, +10 per excluded register, +16 for the
+            // consumed-exit conditional (12 bytes emitted, padded to 16)
             size_t estimatedSize = 128 + (config.excludeFromRestore.size() * 10);
             if (config.consumedExitAddress != 0) {
                 estimatedSize += 16;


### PR DESCRIPTION
Adds a new optional hook field, `consumed_exit_address`. When it's set and the handler returns a non-zero `int` (in EAX), the wrapper jumps to that address instead of resuming at `hookAddress + originalBytes.size()`. This lets a detour hook *selectively consume* an event at runtime — pass through the target's normal flow when the handler returns `0`, or redirect (e.g. to a function epilogue) when it returns non-zero. Default-off; every existing hook is unaffected.

### What's in it
- **Config plumbing** mirrors the existing optional wrapper fields: parsed in `HooksParser`, carried on `Hook`, written to the runtime TOML by `ConfigGenerator`, read back in `config_reader` (accepting the same int-or-hex forms as the `address` field), and passed through the `Patch`/`WrapperConfig` structs.
- **Codegen** emits the cut bytes, then — when the field is set — `TEST EAX,EAX` and a conditional `JMP` to the consumed address. `PUSHFD`/`POPFD` wraps the `TEST` so the cut bytes' EFLAGS survive to the natural-resume path; without it, a cut ending in (or directly before) a flag-consuming `Jcc` would be silently misrouted.

### Caller contract
- Set `consumed_exit_address` to a valid resume point inside the hooked function.
- Add `"eax"` to `exclude_from_restore` so the handler's return value reaches the `TEST`.
- Return non-zero to consume; `0` to fall through.

### Ordering
Built on top of #132 (the selective-POPAD ESP-slot fix) — the `exclude_from_restore = ["eax"]` path this feature relies on is exactly what that PR repairs, so this branch includes its commit. Happy to rebase once #132 lands.

---
*Disclaimer: this is well-tested on my side — it ships in a downstream accessibility mod for KOTOR 1 built on your patcher, and users run it without reported problems. That said, I use AI assistance to write this code, so it's entirely possible some of it is redundant or based on a misunderstanding of your codebase. Please review critically; I'm happy to adjust or drop anything.*
