### PR TITLE
More release tooling fixes

### DIFF
--- a/Patches/create-patch.bat
+++ b/Patches/create-patch.bat
@@ -152,7 +152,12 @@ if !BUILD_DLL! EQU 1 (
         echo   Including GameAPI library files...
     )
 
-    cl /LD /O2 /MD /W3 /EHsc /std:c++17 /I"..\Common" /I"..\..\lib" !CPP_FILES! !COMMON_FILES! /link /DEF:exports.def /LIBPATH:"..\..\lib" sqlite3.lib /OUT:windows_x86.dll >build.log 2>&1
+    REM /MT (static CRT), not /MD: statically link the Visual C++ runtime into the
+    REM DLL so it does not import vcruntime140.dll / msvcp140.dll (the VC++ Redist,
+    REM not guaranteed on a user's machine or in a Wine/Proton prefix). This matches
+    REM the MinGW build in create-patch.py (-static -static-libgcc -static-libstdc++)
+    REM and keeps patch DLLs self-contained -- sqlite3.dll stays the only bundled dep.
+    cl /LD /O2 /MT /W3 /EHsc /std:c++17 /I"..\Common" /I"..\..\lib" !CPP_FILES! !COMMON_FILES! /link /DEF:exports.def /LIBPATH:"..\..\lib" sqlite3.lib /OUT:windows_x86.dll >build.log 2>&1
 
     if !ERRORLEVEL! NEQ 0 (
         echo.

--- a/docs/RELEASE_GUIDE.md
+++ b/docs/RELEASE_GUIDE.md
@@ -7,12 +7,17 @@ collide.
 - **Windows** — `publish.bat`, produces `KotorPatchManager-v<version>.zip`
 - **Linux** — `publish.sh`, produces `KotorPatchManager-linux-v<version>.tar.gz`
 
-Both stage the *same* three Windows DLLs (`KotorPatcher.dll`, `binkw32.dll`,
-`sqlite3.dll`) beside the manager. Those are always Windows binaries because they
-run inside the game process — on Linux the game runs under Wine/Proton, so its
-in-process DLLs are still Windows PE files. The difference is only how the manager
-itself is built and how the patcher gets loaded (injection on Windows, the KProxy
-on Linux). See `src/KProxy/README.md` and `DeploymentPolicy.cs`.
+Both stage Windows DLLs beside the manager, which the applicator copies into the
+game folder at install time. Those are always Windows binaries because they run
+inside the game process — on Linux the game runs under Wine/Proton, so its
+in-process DLLs are still Windows PE files. Both stage `KotorPatcher.dll` (the
+runtime patcher) and `sqlite3.dll` (imported by GameAPI-based patch DLLs to read
+`addresses.db` at runtime — Windows ships `winsqlite3.dll`, not `sqlite3.dll`, so
+it must be bundled). The Linux release additionally stages `binkw32.dll` (the
+KProxy), because on Linux the manager can't inject and loads the patcher via the
+proxy instead; the Windows release injects and does not need it. The difference is
+only how the manager itself is built and how the patcher gets loaded (injection on
+Windows, the KProxy on Linux). See `src/KProxy/README.md` and `DeploymentPolicy.cs`.
 
 The Linux release stages one extra artifact, `KotorPatcher.so`, for KOTOR II's
 native Linux build. That game is an i386 ELF rather than a PE, so it takes a
@@ -27,6 +32,8 @@ native module loaded via `DT_NEEDED` instead of a proxy. See
 
 **Contains**:
 - KPatchLauncher.exe (single self-contained executable)
+- KotorPatcher.dll (runtime patcher, staged beside the launcher)
+- sqlite3.dll (address-database access for GameAPI patch DLLs, staged beside the launcher)
 - create-patch.bat (for users to create patches)
 - Example patches (.kpatch files) - optional
 - README.txt

--- a/publish.bat
+++ b/publish.bat
@@ -32,6 +32,17 @@ if exist "bin\Release\KotorPatcher.dll" (
     echo   [ERROR] KotorPatcher.dll not found in bin\Release\
 )
 
+REM Stage sqlite3.dll beside KotorPatcher.dll. GameAPI-based patch DLLs import
+REM sqlite3.dll to read addresses.db at runtime; the applicator copies it from
+REM here into the game directory at install time. Without it those patches fail
+REM to load in the game (Windows ships winsqlite3.dll, not sqlite3.dll).
+if exist "lib\sqlite3.dll" (
+    copy /Y "lib\sqlite3.dll" "%RELEASE_DIR%\bin\" >nul
+    echo   [OK] sqlite3.dll staged
+) else (
+    echo   [ERROR] lib\sqlite3.dll not found - GameAPI patches will fail at runtime
+)
+
 REM Build launcher
 echo [2/5] Building KPatchLauncher...
 cd src\KPatchLauncher
@@ -76,6 +87,8 @@ set "README_FILE=%RELEASE_DIR%\README.txt"
   echo.
   echo Contents:
   echo   bin/KPatchLauncher.exe - Main application
+  echo   bin/KotorPatcher.dll   - Runtime patcher (injected into the game)
+  echo   bin/sqlite3.dll        - Address database access for GameAPI patch DLLs
   echo   tools/create-patch.bat - Patch creation tool
   echo   patches/ - pre-built patches I've been developing with this project
   echo.

--- a/publish.sh
+++ b/publish.sh
@@ -82,6 +82,20 @@ command -v i686-w64-mingw32-g++ >/dev/null 2>&1 || {
     echo "  [ERROR] i686-w64-mingw32-g++ not found. Install mingw-w64 (i686)."
     exit 1
 }
+# std::thread / std::this_thread (the patcher's deferred-apply path) exist only in
+# MinGW's posix threading model. The Debian/Ubuntu default is win32, where <thread>
+# compiles but defines nothing and the DLL build fails deep in compilation. The build
+# prefers the posix variant when present (see the Makefile and KProxy build-mingw.sh),
+# so check that same compiler here and fail fast with a fix on a win32-only host.
+MINGW_CXX="$(command -v i686-w64-mingw32-g++-posix 2>/dev/null || echo i686-w64-mingw32-g++)"
+printf '#include <thread>\n#include <chrono>\nvoid f(){ std::thread t; std::this_thread::sleep_for(std::chrono::milliseconds(1)); }\n' \
+    | "$MINGW_CXX" -std=c++17 -fsyntax-only -x c++ - >/dev/null 2>&1 || {
+    echo "  [ERROR] MinGW ($MINGW_CXX) lacks std::thread (win32 threading model)."
+    echo "          Install and select the posix variant, which provides it:"
+    echo "            sudo apt install g++-mingw-w64-i686-posix"
+    echo "            sudo update-alternatives --set i686-w64-mingw32-g++ /usr/bin/i686-w64-mingw32-g++-posix"
+    exit 1
+}
 # KotorPatcher.so needs a working 32-bit native toolchain, which a plain `command -v g++`
 # does not prove: a host g++ without the 32-bit dev libraries only fails at link time.
 # Compile a throwaway to confirm -m32 links before committing to a release build.

--- a/src/KProxy/build-mingw.sh
+++ b/src/KProxy/build-mingw.sh
@@ -8,7 +8,10 @@ set -euo pipefail
 
 cd "$(dirname "$0")"
 
-CXX="${CXX:-i686-w64-mingw32-g++}"
+# Prefer MinGW's posix threading variant when present (Debian/Ubuntu ship it as a
+# separate binary; the shared patcher core uses std::thread, which the win32 model
+# lacks). Falls back to the plain name where the default is already posix (Fedora).
+CXX="${CXX:-$(command -v i686-w64-mingw32-g++-posix 2>/dev/null || echo i686-w64-mingw32-g++)}"
 OUT="${1:-binkw32.dll}"
 
 "$CXX" -std=c++17 -shared -O2 -s \

--- a/src/KotorPatcher/Makefile
+++ b/src/KotorPatcher/Makefile
@@ -11,7 +11,13 @@
 # sqlite is not linked: the runtime calls no sqlite symbol (only the per-patch
 # DLLs use it, through their own GameAPI build).
 
-CXX_WIN   := i686-w64-mingw32-g++
+# MinGW-w64 ships two threading models. std::thread / std::this_thread (used by the
+# deferred-apply path in the patcher) exist only in the posix model; the win32 model
+# -- the Debian/Ubuntu default -- includes <thread> fine but defines nothing, so the
+# build fails deep in compilation. Prefer the posix variant when the distro provides
+# it as a separate binary (Debian/Ubuntu); fall back to the plain name where the
+# default is already posix (Fedora). Override with CXX_WIN=... in the environment.
+CXX_WIN   ?= $(shell command -v i686-w64-mingw32-g++-posix 2>/dev/null || echo i686-w64-mingw32-g++)
 CXX_LINUX := g++
 
 BUILD    := build
@@ -43,20 +49,37 @@ LINUX_SRCS := $(CORE_SRCS) src/platform_posix.cpp src/soentry.cpp
 WIN_OBJS   := $(patsubst src/%.cpp,$(BUILD)/win/%.o,$(WIN_SRCS))
 LINUX_OBJS := $(patsubst src/%.cpp,$(BUILD)/linux/%.o,$(LINUX_SRCS))
 
-# Overridable so the release scripts can link straight to an absolute output path.
-DLL_OUT ?= $(BUILD)/KotorPatcher.dll
-SO_OUT  ?= $(BUILD)/KotorPatcher.so
+# Always build to these fixed, space-free in-tree paths. The final destinations
+# (DLL_OUT/SO_OUT) may be absolute paths under a directory containing spaces -- the
+# release tree lives under ".../KotOR Patch Manager/" -- and Make cannot use such a
+# path as a target: it splits target and prerequisite lists on whitespace, so a
+# spaced path silently becomes several bogus targets. Build here, then copy to the
+# requested destination in the recipe below, where the shell (not Make) handles the
+# spaces via quoting.
+BUILD_DLL := $(BUILD)/KotorPatcher.dll
+BUILD_SO  := $(BUILD)/KotorPatcher.so
+
+# Optional final destination for each artifact. When set, the dll/so target copies
+# the built binary there (the release scripts use this to drop it into the release
+# tree); when empty, the binary is left at its BUILD_* path. Overridable in the env.
+DLL_OUT ?=
+SO_OUT  ?=
 
 .PHONY: all dll so clean
 all: dll so
-dll: $(DLL_OUT)
-so:  $(SO_OUT)
 
-$(DLL_OUT): $(WIN_OBJS)
+# The copy is skipped when DLL_OUT/SO_OUT is empty or already points at the built
+# file (-ef: same file), so `make dll DLL_OUT=<build path>` can't cp a file onto itself.
+dll: $(BUILD_DLL)
+	@if [ -n "$(DLL_OUT)" ] && [ ! "$(DLL_OUT)" -ef "$(BUILD_DLL)" ]; then cp -f "$(BUILD_DLL)" "$(DLL_OUT)"; fi
+so: $(BUILD_SO)
+	@if [ -n "$(SO_OUT)" ] && [ ! "$(SO_OUT)" -ef "$(BUILD_SO)" ]; then cp -f "$(BUILD_SO)" "$(SO_OUT)"; fi
+
+$(BUILD_DLL): $(WIN_OBJS)
 	@mkdir -p $(dir $@)
 	$(CXX_WIN) $(WIN_CXXFLAGS) -o $@ $^ $(WIN_LDFLAGS)
 
-$(SO_OUT): $(LINUX_OBJS)
+$(BUILD_SO): $(LINUX_OBJS)
 	@mkdir -p $(dir $@)
 	$(CXX_LINUX) $(LINUX_CXXFLAGS) -o $@ $^ $(LINUX_LDFLAGS)
 


### PR DESCRIPTION
This PR includes:
- Fixes a bug with the publish shell script that misinterprets space characters in resolved WSL paths
- Explicitly includes `sqlite3.dll` in the Windows release bin, as this library is not guaranteed on all platforms
- Use static linking for create-patch.bat to avoid potential issues with missing VC++ redistributable
- Updated the release guide
- Added guard for different linux thread models causing build errors