### PR TITLE
Add three KOTOR 1 renderer fixes: texture bucket safety, grass double free, grass rendering

### DIFF
--- a/Patches/GrassMemorySafety/kotor1_103.hooks.toml
+++ b/Patches/GrassMemorySafety/kotor1_103.hooks.toml
@@ -1,0 +1,38 @@
+[metadata]
+target_versions = [
+    "761F9466F456A83909036BAEBB5C43167D722387BE66E54617BA20A8C49E9886",
+    "9C10E0450A6EECA417E036E3CDE7474FED1F0A92AAB018446D156944DEA91435"
+]
+
+# DestroyGrassPolys (0x004A8460).
+# free() at 0x006FB7B2 guards NULL explicitly, so zeroing the argument is a safe
+# no-op. The push is left on the stack for the caller's existing 'add esp, 8'.
+# The call is absolute (mov eax,imm32 / call eax) so the block is relocatable.
+[[hooks]]
+address = 0x004A847C
+type = "replace"
+original_bytes = [
+    0x8B, 0x56, 0x3C, 0x52, 0xE8, 0x0B, 0x1F, 0x25,
+    0x00
+]
+replacement_bytes = [
+    0x8B, 0x56, 0x3C, 0x3B, 0x56, 0x38, 0x75, 0x02,
+    0x33, 0xD2, 0x52, 0xB8, 0x90, 0xA3, 0x6F, 0x00,
+    0xFF, 0xD0
+]
+
+# ~CAurTriangleBin (0x004A8350) -- identical sequence, eax instead of edx.
+# Flagged by Lane on review: if the double free is real, the destructor needs the
+# same treatment. ecx is dead here (this was moved to esi at 0x004A8368).
+[[hooks]]
+address = 0x004A8380
+type = "replace"
+original_bytes = [
+    0x8B, 0x46, 0x3C, 0x50, 0xE8, 0x07, 0x20, 0x25,
+    0x00
+]
+replacement_bytes = [
+    0x8B, 0x46, 0x3C, 0x3B, 0x46, 0x38, 0x75, 0x02,
+    0x33, 0xC0, 0x50, 0xB9, 0x90, 0xA3, 0x6F, 0x00,
+    0xFF, 0xD1
+]

--- a/Patches/GrassMemorySafety/manifest.toml
+++ b/Patches/GrassMemorySafety/manifest.toml
@@ -1,0 +1,14 @@
+[patch]
+id = "grass-memory-safety"
+name = "Grass Buffer Double Free"
+version = "1.0.0"
+author = "VexFlint"
+description = "CreateArrays stores one allocation in two fields (0x38 and 0x3c); DestroyGrassPolys and ~CAurTriangleBin both free each of them. The 0x3c field is only ever assigned 0 or the 0x38 pointer, never its own allocation, so the first free is either free(NULL) or a double free of the same block. Frees the alias only when it genuinely differs, so nothing leaks if 0x3c ever holds an independent allocation."
+
+requires = []
+
+conflicts = []
+
+[patch.supported_versions]
+kotor1_cdcrack_103 = "761F9466F456A83909036BAEBB5C43167D722387BE66E54617BA20A8C49E9886"
+kotor1_gog_103 = "9C10E0450A6EECA417E036E3CDE7474FED1F0A92AAB018446D156944DEA91435"

--- a/Patches/GrassRenderFix/kotor1_103.hooks.toml
+++ b/Patches/GrassRenderFix/kotor1_103.hooks.toml
@@ -1,0 +1,82 @@
+[metadata]
+target_versions = [
+    "761F9466F456A83909036BAEBB5C43167D722387BE66E54617BA20A8C49E9886",
+    "9C10E0450A6EECA417E036E3CDE7474FED1F0A92AAB018446D156944DEA91435"
+]
+
+# RenderGrassPolys -- multitexture path vertex pointer.
+# lea eax,[esi+0x40] -> mov eax,[esi+0x38]: pass the allocated blade buffer instead
+# of the address of an always-zero field. The ATI path at 0x004A6FFC already does
+# this correctly and is deliberately left untouched.
+[[hooks]]
+address = 0x004A7114
+type = "simple"
+original_bytes = [
+    0x8D, 0x46, 0x40
+]
+replacement_bytes = [
+    0x8B, 0x46, 0x38
+]
+
+# RenderGrassPolys -- fallback path vertex pointer. Same change.
+[[hooks]]
+address = 0x004A71CE
+type = "simple"
+original_bytes = [
+    0x8D, 0x46, 0x40
+]
+replacement_bytes = [
+    0x8B, 0x46, 0x38
+]
+
+# RenderGrassPolys fallback path -- disable the client-state arrays before returning.
+# This path reaches its return via 'goto LAB_004A71DC' without the glDisableClientState
+# calls the other two paths make through LAB_004A7196, so later draws inherit a stale
+# normal array. glDisableClientState is __stdcall, so no stack fixup is needed.
+[[hooks]]
+address = 0x004A71D4
+type = "replace"
+original_bytes = [
+    0xE8, 0x57, 0xF0, 0xF7, 0xFF, 0x83, 0xC4, 0x18
+]
+replacement_bytes = [
+    0xB8, 0x30, 0x62, 0x42, 0x00, 0xFF, 0xD0, 0x83,
+    0xC4, 0x18, 0x8B, 0x15, 0x98, 0xF3, 0x73, 0x00,
+    0x52, 0xFF, 0x15, 0x64, 0xD2, 0x73, 0x00, 0x8B,
+    0x15, 0x9C, 0xF3, 0x73, 0x00, 0x52, 0xFF, 0x15,
+    0x64, 0xD2, 0x73, 0x00, 0x8B, 0x15, 0xA4, 0xF3,
+    0x73, 0x00, 0x52, 0xFF, 0x15, 0x64, 0xD2, 0x73,
+    0x00
+]
+
+# RenderGrassPolys -- save GL state before the material is set.
+# Mask 0x42041 = GL_CURRENT_BIT | GL_LIGHTING_BIT | GL_ENABLE_BIT | GL_TEXTURE_BIT.
+# GL_TEXTURE_BIT is required: without it, per-frame lighting is correct but state
+# still leaks across module reloads.
+# Placed after every early return in the function, so push/pop are always balanced.
+[[hooks]]
+address = 0x004A6E01
+type = "replace"
+original_bytes = [
+    0x8B, 0x15, 0x44, 0x1E, 0x83, 0x00
+]
+replacement_bytes = [
+    0x68, 0x41, 0x20, 0x04, 0x00, 0xFF, 0x15, 0x68,
+    0xD2, 0x73, 0x00, 0x8B, 0x15, 0x44, 0x1E, 0x83,
+    0x00
+]
+
+# RenderGrassPolys -- restore GL state at the shared tail.
+# The function has exactly one ret (0x004A71FD). Everything branching to 0x004A71DC
+# originates after the push above; the early exits at 0x004A7200+ all originate
+# before it and carry their own epilogue, so they never reach this pop.
+[[hooks]]
+address = 0x004A71DC
+type = "replace"
+original_bytes = [
+    0x8B, 0x4E, 0x0C, 0xA1, 0xB0, 0x7F, 0x82, 0x00
+]
+replacement_bytes = [
+    0xFF, 0x15, 0x6C, 0xD2, 0x73, 0x00, 0x8B, 0x4E,
+    0x0C, 0xA1, 0xB0, 0x7F, 0x82, 0x00
+]

--- a/Patches/GrassRenderFix/manifest.toml
+++ b/Patches/GrassRenderFix/manifest.toml
@@ -1,0 +1,14 @@
+[patch]
+id = "grass-render-fix"
+name = "Grass Rendering Fix"
+version = "1.0.0"
+author = "VexFlint"
+description = "Fixes grass rendering as stretched geometry across the sky. RenderGrassPolys has three draw paths; the two taken when aurATIFragmentShadersBumpMapAvailable() returns false pass &field_0x40 -- a field only ever assigned 0 -- to glVertexPointer instead of the allocated blade buffer at field_0x38, so OpenGL reads object fields as vertex coordinates. Also restores GL state the same function leaks: one path returns with three client-state arrays still enabled, and material/texture state is never restored, which breaks lighting on later draws and across module reloads."
+
+requires = []
+
+conflicts = []
+
+[patch.supported_versions]
+kotor1_cdcrack_103 = "761F9466F456A83909036BAEBB5C43167D722387BE66E54617BA20A8C49E9886"
+kotor1_gog_103 = "9C10E0450A6EECA417E036E3CDE7474FED1F0A92AAB018446D156944DEA91435"

--- a/Patches/TextureBucketSafety/kotor1_103.hooks.toml
+++ b/Patches/TextureBucketSafety/kotor1_103.hooks.toml
@@ -1,0 +1,42 @@
+[metadata]
+target_versions = [
+    "761F9466F456A83909036BAEBB5C43167D722387BE66E54617BA20A8C49E9886",
+    "9C10E0450A6EECA417E036E3CDE7474FED1F0A92AAB018446D156944DEA91435"
+]
+
+# AurTextureGetMaxTexID (0x0041FEB0) -- saturate the return value.
+# Its only caller is ClearBuckets, which uses it as an iteration count over three
+# 5000-entry arrays. Saturating rather than masking: an AND would wrap a legitimate
+# max of e.g. 4500 down to 404 and leave stale buckets uncleared.
+# Returns on both paths, so it never reaches the automatic jump-back.
+[[hooks]]
+address = 0x0041FEB5
+type = "replace"
+original_bytes = [
+    0xC3, 0x90, 0x90, 0x90, 0x90
+]
+replacement_bytes = [
+    0x3D, 0x88, 0x13, 0x00, 0x00, 0x72, 0x05, 0xB8,
+    0x87, 0x13, 0x00, 0x00, 0xC3
+]
+
+# AddPartToMeshBuckets (0x0046BDF0) -- range-check the texture ID.
+# meshBuckets ends at 0x827F40, which is exactly backgroundBucket, so an overrun
+# lands on the skybox list first. The function has two halves: the texID-indexed
+# bucket insert (unsafe) and an unconditional meshShadowBucket append at 0x0046BEB1
+# (always safe). The bail path rejoins at 0x0046BEB1 so shadow casting is preserved.
+# push imm32 / ret rather than a rel32 jump, so the block is position-independent.
+[[hooks]]
+address = 0x0046BE64
+type = "replace"
+original_bytes = [
+    0x8D, 0x34, 0x40, 0x8B, 0x04, 0xB5, 0xE8, 0x94,
+    0x81, 0x00
+]
+replacement_bytes = [
+    0x3D, 0x88, 0x13, 0x00, 0x00, 0x72, 0x13, 0xA1,
+    0xBC, 0xBF, 0x7F, 0x00, 0x8B, 0x0D, 0xB8, 0xBF,
+    0x7F, 0x00, 0x3B, 0xC8, 0x68, 0xB1, 0xBE, 0x46,
+    0x00, 0xC3, 0x8D, 0x34, 0x40, 0x8B, 0x04, 0xB5,
+    0xE8, 0x94, 0x81, 0x00
+]

--- a/Patches/TextureBucketSafety/manifest.toml
+++ b/Patches/TextureBucketSafety/manifest.toml
@@ -1,0 +1,14 @@
+[patch]
+id = "texture-bucket-safety"
+name = "Texture Bucket Memory Safety"
+version = "1.0.0"
+author = "VexFlint"
+description = "Bounds-checks the three 5000-entry texture bucket arrays (meshBuckets, fadeBuckets, capBuckets), which are indexed by driver-assigned GL texture names. ClearBuckets used maxTexID+1 as an iteration count without clamping (crash 0x0046BF22), and AddPartToMeshBuckets indexed and wrote through the arrays with no range check (crash 0x0046BEAE). Out-of-range parts skip the bucket insert but still reach meshShadowBucket, and are unreachable by the renderer anyway since DoMeshBuckets iterates the clamped AurTextureGetOrdering list."
+
+requires = []
+
+conflicts = []
+
+[patch.supported_versions]
+kotor1_cdcrack_103 = "761F9466F456A83909036BAEBB5C43167D722387BE66E54617BA20A8C49E9886"
+kotor1_gog_103 = "9C10E0450A6EECA417E036E3CDE7474FED1F0A92AAB018446D156944DEA91435"


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>Add three KOTOR 1 renderer fixes: texture bucket safety, grass double free, grass rendering</h1>
<p>Adds three patches for KOTOR 1. The headline one fixes grass rendering as stretched
geometry across the sky — Lane reproduced this independently on an RTX 4090 by forcing
the game down the non-ATI path.</p>
<p>All addresses are <code>kotor1_cdcrack_103</code>. Declared for <code>kotor1_gog_103</code> as well, since the
two differ only by the cracker's signature, but I've only tested <code>cdcrack</code> myself.</p>

Patch | id | Hooks
-- | -- | --
TextureBucketSafety | texture-bucket-safety | 2
GrassMemorySafety | grass-memory-safety | 2
GrassRenderFix | grass-render-fix | 5


<p>That argument goes straight into <code>glVertexPointer</code>. The field at <code>0x40</code> is only ever
assigned <code>0</code> — it never receives a buffer — so two of the three paths hand OpenGL a
pointer into the <code>CAurTriangleBin</code> object itself and the blade positions come from
adjacent object fields reinterpreted as floats.</p>
<p>Which path you take depends on <code>aurATIFragmentShadersBumpMapAvailable()</code>. It returns true
on plenty of modern hardware, which is why this isn't universal; when it returns false you
get the broken path. In the cases seen so far that happens when the game ends up running
on integrated graphics.</p>
<p>Fixed by pointing both broken sites at <code>[esi+0x38]</code>. Same instruction length, so these are
<code>simple</code> hooks. <strong>The ATI path is left untouched.</strong></p>
<p>The same function also leaks GL state, which this patch fixes alongside:</p>
<ul>
<li>The fallback path returns via <code>goto LAB_004A71DC</code> without the <code>glDisableClientState</code>
calls the other two paths make through <code>LAB_004A7196</code>, so later draws inherit a stale
normal array.</li>
<li>Material and texture state set at the top is never restored, which breaks lighting
across module reloads until the GL context resets. Wrapped in
<code>glPushAttrib(GL_CURRENT | GL_LIGHTING | GL_ENABLE | GL_TEXTURE)</code> / <code>glPopAttrib</code>.
<code>GL_TEXTURE_BIT</code> is required — without it, per-frame lighting is correct but the
cross-reload case still breaks.</li>
</ul>
<p>Push/pop balance: <code>RenderGrassPolys</code> has exactly one <code>ret</code> (<code>0x004A71FD</code>). Everything
branching to <code>0x004A71DC</code> originates after the push at <code>0x004A6E01</code>; the early exits at
<code>0x004A7200</code>+ all originate before it and carry their own epilogue, so they never reach
the pop.</p>
<h2>GrassMemorySafety</h2>
<p><code>CreateArrays</code> stores one allocation in two fields:</p>
<pre><code class="language-c">this-&gt;field17_0x38 = operator_new(...);
this-&gt;field18_0x3c = this-&gt;field17_0x38;
</code></pre>
<p>and both <code>DestroyGrassPolys</code> (<code>0x004A8460</code>) and <code>~CAurTriangleBin</code> (<code>0x004A8350</code>) free
each of them. The <code>0x3c</code> field is only ever assigned <code>0</code> or the <code>0x38</code> pointer, never its
own allocation.</p>
<p><code>free</code> (<code>0x006FB7B2</code>) guards NULL explicitly, so the null case is harmless — the double
free happens when <code>0x3c</code> is non-null and equal to <code>0x38</code>.</p>
<p>Per Lane's review suggestion, this frees the alias only when it genuinely differs, rather
than forcing it to NULL, so nothing leaks if <code>0x3c</code> ever holds an independent allocation
that static analysis didn't surface. The destructor site was also his catch.</p>
<h2>TextureBucketSafety</h2>
<p><code>meshBuckets</code>, <code>fadeBuckets</code> and <code>capBuckets</code> are 5000 entries each and are indexed by
driver-assigned GL texture names, which climb across module loads rather than being
recycled.</p>
<ul>
<li><code>ClearBuckets</code> uses <code>maxTexID + 1</code> as an iteration count with no clamp — observed
crashing at <code>0x0046BF22</code>. <code>AurTextureGetMaxTexID</code> has exactly one caller, so clamping
its return value is surgical. Saturates rather than masks: an <code>AND</code> would wrap a
legitimate max of 4500 down to 404 and leave stale buckets uncleared.</li>
<li><code>AddPartToMeshBuckets</code> indexes and writes through the arrays with no range check —
observed crashing at <code>0x0046BEAE</code>, <code>mov [esi+4],edx</code> where <code>esi = meshBuckets + texID*12</code>.</li>
</ul>
<p>Worth noting <code>meshBuckets</code> ends at <code>0x827F40</code>, which is exactly <code>backgroundBucket</code>, so an
overrun lands on the skybox list first.</p>
<p>Skipping out-of-range parts loses nothing renderable: <code>DoMeshBuckets</code> iterates the list
from <code>AurTextureGetOrdering</code>, which is already clamped to <code>&lt; 5000</code>. The bail path rejoins
at <code>0x0046BEB1</code> so the unconditional <code>meshShadowBucket</code> append still runs — an earlier
version returned early and silently disabled shadow casting for those parts, which Lane
caught on review.</p>
<p>This is damage control, not a repair — the underlying issue is the fixed 5000-entry
ceiling. See "Not addressed here" below.</p>
<hr>
<h2>Implementation notes</h2>
<p><strong>No relative branches to game code.</strong> <code>replace</code> blocks are relocated into memory KPM
allocates, so a <code>rel32</code> <code>call</code>/<code>jmp</code> in <code>replacement_bytes</code> would land somewhere
arbitrary. Every call here is absolute — <code>mov reg, imm32</code> / <code>call reg</code> for <code>free</code> and
<code>DrawLightmappedGrass</code>, <code>call [iat_slot]</code> for the GL entry points — and the one
intra-function jump uses <code>push imm32</code> / <code>ret</code>.</p>
<p><strong>Fall-through vs. explicit return.</strong> Most blocks fall off the end so the automatic
jump-back resumes the original code. The exception is the clamp in <code>TextureBucketSafety</code>,
which returns on both paths and never reaches the jump-back — deliberate, since the
instruction it replaces <em>is</em> the <code>ret</code>.</p>
<p><strong>Hook interaction.</strong> Inside <code>GrassRenderFix</code> the client-state block resumes at
<code>0x004A71DC</code>, which is also where the <code>glPopAttrib</code> hook is installed. Intended: the
resume lands on that hook's jump and the state restore still runs.</p>
<p><strong>Not included:</strong> a frame cap and the 4GB flag. 4GB duplicates the existing <code>4gb-patch</code>,
and the frame cap is a preference rather than a bug fix. Both live in a standalone exe
patcher instead.</p>
<hr>
<h2>Testing</h2>
<p>Confirmed in play on <code>kotor1_cdcrack_103</code>, AMD hardware, ~180 mod build (KOTOR 1
Spoiler-Free Build), UniWS widescreen, across a long Dantooine and Taris session.</p>
<p>Every <code>original_bytes</code> sequence was verified programmatically against a stock executable
before the TOML was generated, rather than transcribed by hand. Each replacement block was
disassembled and checked.</p>
<p>Grass before/after on Dantooine is the fastest visual check.</p>
<p>What I have <strong>not</strong> tested: the GOG build, and applying these through KPM on an
unmodified executable — my exe is UniWS-patched, so the SHA-256 gate rejects it. Happy to
adjust anything the hash-gating work needs.</p>
<hr>
<h2>Not addressed here</h2>
<p>The 5000-entry ceiling itself. Texture names from <code>glGenTextures</code> climb monotonically as
modules load and unload rather than being reused, so a long session eventually exceeds the
arrays — my crash implied roughly 19,552, which can't be a live texture count in a 32-bit
process. A free list around <code>glGenTextures</code> / <code>glDeleteTextures</code> would keep names bounded
by peak live textures with no game code touched, but it needs a DLL-side component rather
than byte hooks. Happy to attempt it separately if that's a direction you'd want.</p>
<p>Full reverse-engineering notes, including the reasoning and the theories that turned out
wrong, are at https://github.com/VexFlint/KOTOR_FPS_CAP — see <code>TECHNICAL.md</code>.</p></body></html><!--EndFragment-->
</body>
</html>
<img width="1585" height="894" alt="grass_bug_high_FPS" src="https://github.com/user-attachments/assets/3b1f7c86-985d-40ce-9d12-351f4e52c56f" />
<img width="1585" height="891" alt="Grass_bug" src="https://github.com/user-attachments/assets/55e99673-150f-4205-9fb6-2ce87d45ebe7" />
