### PR TITLE
Add a patch that fixes cube maps on Intel graphics

### DIFF
--- a/Patches/CubeMapFix/kotor1.hooks.toml
+++ b/Patches/CubeMapFix/kotor1.hooks.toml
@@ -1,0 +1,34 @@
+[metadata]
+target_versions = [
+    "9C10E0450A6EECA417E036E3CDE7474FED1F0A92AAB018446D156944DEA91435",
+    "34E6D971C034222A417995D8E1E8FDD9F8781795C9C289BD86C499A439F34C88",
+    "761F9466F456A83909036BAEBB5C43167D722387BE66E54617BA20A8C49E9886",
+]
+# KOTOR 1
+# Cube map extension name fix.
+#
+# InitExtensions (0x00436490) tests the driver's GL_EXTENSIONS string for
+# "GL_EXT_texture_cube_map". Intel's Windows driver only exposes the ARB spelling, so
+# EXT_TEXTURE_CUBE_MAP_BIT (0x02) never gets set, AurCubeMapAvailable (0x0045F8B0)
+# reports false, and env-mapped surfaces fall back to GL_SPHERE_MAP texgen.
+#
+# Searching for the ARB name instead is safe: both names are 23 bytes, the literal has
+# a single xref (InitExtensions at 0x004365AA), and ARB, EXT and core 1.3 share
+# identical enums with no entry points. EXT was derived from ARB, so drivers that work
+# today advertise both.
+#
+# AurCubeMapAvailable also needs ARB_MULTITEXTURE_BIT (0x10). The runtime check is
+# existingExtensions & 0x12 == 0x12.
+
+[[hooks]]
+# "GL_EXT_texture_cube_map" -> "GL_ARB_texture_cube_map"
+address = 0x00740968
+type = "simple"
+original_bytes = [
+    0x47, 0x4C, 0x5F, 0x45, 0x58, 0x54, 0x5F, 0x74, 0x65, 0x78, 0x74, 0x75,
+    0x72, 0x65, 0x5F, 0x63, 0x75, 0x62, 0x65, 0x5F, 0x6D, 0x61, 0x70,
+]
+replacement_bytes = [
+    0x47, 0x4C, 0x5F, 0x41, 0x52, 0x42, 0x5F, 0x74, 0x65, 0x78, 0x74, 0x75,
+    0x72, 0x65, 0x5F, 0x63, 0x75, 0x62, 0x65, 0x5F, 0x6D, 0x61, 0x70,
+]

--- a/Patches/CubeMapFix/manifest.toml
+++ b/Patches/CubeMapFix/manifest.toml
@@ -1,0 +1,24 @@
+[patch]
+id = "cube-map-fix"
+name = "KOTOR 1 Cube Map Fix"
+version = "1.0.0"
+author = "Synchro"
+description = """
+Fixes missing reflections on Intel graphics under Windows.
+
+On these systems KOTOR 1 fails to detect the graphics feature it uses for shiny \
+surfaces, so armour, lightsabers, polished floors and other reflective materials \
+lose their sheen and look flat. This patch corrects the detection so reflections \
+render the way they were meant to.
+
+It makes no difference on AMD or NVIDIA cards, or on Linux, where the game already \
+detects the feature correctly."""
+
+requires = []
+
+conflicts = []
+
+[patch.supported_versions]
+kotor1_gog_103 = "9C10E0450A6EECA417E036E3CDE7474FED1F0A92AAB018446D156944DEA91435"
+kotor1_steam_103 = "34E6D971C034222A417995D8E1E8FDD9F8781795C9C289BD86C499A439F34C88"
+kotor1_cdcrack_103 = "761F9466F456A83909036BAEBB5C43167D722387BE66E54617BA20A8C49E9886"


### PR DESCRIPTION
KOTOR 1 tests the driver's GL_EXTENSIONS string for `GL_EXT_texture_cube_map`.

Intel's Windows driver exposes cube maps only under the ARB name, so the check fails, `EXT_TEXTURE_CUBE_MAP_BIT` stays clear, and AurCubeMapAvailable reports false for the rest of the process. Every env-mapped surface then renders through `GL_SPHERE_MAP`'s texgen instead of a cube map.

Patches `GL_EXT_texture_cube_map` to check for and use `GL_ARB_texture_cube_map` instead, which fixes rendering.

Both extensions use the same struct so they are interchangeable, and most other graphics vendors expose support for both extensions so this patch doesn't affect functionality if enabled on a non-Intel machine.