### PR TITLE
`RunConsoleCommand` and `GetPlayerLastTarget` extensions

### DIFF
--- a/Patches/Common/GameAPI/CServerExoApp.cpp
+++ b/Patches/Common/GameAPI/CServerExoApp.cpp
@@ -9,6 +9,7 @@ CServerExoApp::GetPlayerCreatureIdFn CServerExoApp::getPlayerCreatureId = nullpt
 CServerExoApp::GetCreatureByGameObjectIDFn CServerExoApp::getCreatureByGameObjectID = nullptr;
 CServerExoApp::GetPlayerCreatureFn CServerExoApp::getPlayerCreature = nullptr;
 CServerExoApp::GetGlobalVariableTableFn CServerExoApp::getGlobalVariableTable = nullptr;
+CServerExoApp::ClientToServerObjectIdFn CServerExoApp::clientToServerObjectId = nullptr;
 bool CServerExoApp::functionsInitialized = false;
 bool CServerExoApp::offsetsInitialized = false;
 
@@ -43,6 +44,10 @@ void CServerExoApp::InitializeFunctions() {
 
         getGlobalVariableTable = reinterpret_cast<GetGlobalVariableTableFn>(
             GameVersion::GetFunctionAddress("CServerExoApp", "GetGlobalVariableTable")
+        );
+
+        clientToServerObjectId = reinterpret_cast<ClientToServerObjectIdFn>(
+            GameVersion::GetFunctionAddress("CServerExoApp", "ClientToServerObjectId")
         );
     }
     catch (const GameVersionException& e) {
@@ -139,4 +144,13 @@ void* CServerExoApp::GetGlobalVariableTable() {
     }
 
     return getGlobalVariableTable(objectPtr);
+}
+
+DWORD CServerExoApp::ClientToServerObjectId(DWORD clientId) {
+    if (!objectPtr || !clientToServerObjectId) {
+        debugLog("[CServerExoApp] Error: no objectPtr or no clientToServerObjectId");
+        return 0x7F000000;
+    }
+
+    return clientToServerObjectId(objectPtr, clientId);
 }

--- a/Patches/Common/GameAPI/CServerExoApp.h
+++ b/Patches/Common/GameAPI/CServerExoApp.h
@@ -16,6 +16,7 @@ public:
     CSWSCreature* GetCreatureByGameObjectID(DWORD objectId);
     CSWSCreature* GetPlayerCreature();
     void* GetGlobalVariableTable();
+    DWORD ClientToServerObjectId(DWORD clientId);
 
     // Override virtual methods from GameAPIObject
     void InitializeFunctions() override;
@@ -30,12 +31,14 @@ private:
     typedef void* (__thiscall* GetCreatureByGameObjectIDFn)(void* thisPtr, DWORD objectId);
     typedef void* (__thiscall* GetPlayerCreatureFn)(void* thisPtr);
     typedef void* (__thiscall* GetGlobalVariableTableFn)(void* thisPtr);
+    typedef DWORD(__thiscall* ClientToServerObjectIdFn)(void* thisPtr, DWORD clientId);
 
     static GetObjectArrayFn getObjectArray;
     static GetPlayerCreatureIdFn getPlayerCreatureId;
     static GetCreatureByGameObjectIDFn getCreatureByGameObjectID;
     static GetPlayerCreatureFn getPlayerCreature;
     static GetGlobalVariableTableFn getGlobalVariableTable;
+    static ClientToServerObjectIdFn clientToServerObjectId;
 
     static bool functionsInitialized;
     static bool offsetsInitialized;

--- a/Patches/ScriptExtender/Extensions/consoleCommand.cpp
+++ b/Patches/ScriptExtender/Extensions/consoleCommand.cpp
@@ -1,0 +1,30 @@
+#include "consoleCommand.h"
+
+VirtualMachineReturnTypes __stdcall ExecuteCommandRunConsoleCommand(DWORD routine, int paramCount) {
+	CVirtualMachine* vm = CVirtualMachine::GetInstance();
+	if (!vm) return COMMAND_PARAM_ERROR;
+
+	CExoString command;
+	if (!vm->StackPopString(&command)) {
+		delete vm;
+		return COMMAND_PARAM_ERROR;
+	}
+
+	typedef char*(__cdecl* FuncInterpFn)(char* consoleCommand);
+	FuncInterpFn funcInterp = 
+		reinterpret_cast<FuncInterpFn>(
+			GameVersion::GetFunctionAddress("Global", "FuncInterp")
+			);
+
+	debugLog("[ScriptExtender] Running Console Command %s", command.GetCStr());
+
+	char* result = funcInterp(command.GetCStr());
+
+	CExoString returnVal(result);
+	if (!vm->StackPushString(&returnVal)) {
+		delete vm;
+		return COMMAND_RETURN_ERROR;
+	}
+
+	return SUCCESS;
+}

--- a/Patches/ScriptExtender/Extensions/consoleCommand.h
+++ b/Patches/ScriptExtender/Extensions/consoleCommand.h
@@ -1,0 +1,6 @@
+#pragma once
+#include "Common.h"
+#include "GameAPI/CVirtualMachine.h"
+
+const int RunConsoleCommandIndex = 799;
+VirtualMachineReturnTypes __stdcall ExecuteCommandRunConsoleCommand(DWORD routine, int paramCount);

--- a/Patches/ScriptExtender/Extensions/globalModifiers.cpp
+++ b/Patches/ScriptExtender/Extensions/globalModifiers.cpp
@@ -39,12 +39,14 @@ VirtualMachineReturnTypes __stdcall ExecuteCommandAdjustGlobalNumber(DWORD routi
     int value = prev + amount;
 
     if (value > 127 || value < -128) {
+        delete server;
         delete vm;
         return COMMAND_RETURN_ERROR;
     }
 
     setValueNumber(globalVars, indentifier.GetPtr(), value);
 
+    delete server;
     delete vm;
 
     return SUCCESS;

--- a/Patches/ScriptExtender/Extensions/lastTarget.cpp
+++ b/Patches/ScriptExtender/Extensions/lastTarget.cpp
@@ -1,0 +1,24 @@
+#include "lastTarget.h"
+
+VirtualMachineReturnTypes __stdcall ExecuteCommandetGetPlayerLastTarget(DWORD routine, int paramCount) {
+	CVirtualMachine* vm = CVirtualMachine::GetInstance();
+	if (!vm) return COMMAND_PARAM_ERROR;
+
+	CServerExoApp* server = CServerExoApp::GetInstance();
+	CClientExoApp* client = CClientExoApp::GetInstance();
+
+	DWORD clientTarget = client->GetLastTarget();
+	DWORD serverTarget = server->ClientToServerObjectId(clientTarget);
+
+	if (!vm->StackPushObject(serverTarget)) {
+		delete server;
+		delete client;
+		delete vm;
+		return COMMAND_RETURN_ERROR;
+	}
+
+	delete server;
+	delete client;
+	delete vm;
+	return SUCCESS;
+}

--- a/Patches/ScriptExtender/Extensions/lastTarget.h
+++ b/Patches/ScriptExtender/Extensions/lastTarget.h
@@ -1,0 +1,8 @@
+#pragma once
+#include "Common.h"
+#include "GameAPI/CVirtualMachine.h"
+#include "GameAPI/CServerExoApp.h"
+#include "GameAPI/CClientExoApp.h"
+
+const int GetPlayerLastTargetObjectIndex = 800;
+VirtualMachineReturnTypes __stdcall ExecuteCommandetGetPlayerLastTarget(DWORD routine, int paramCount);

--- a/Patches/ScriptExtender/ScriptExtender.cpp
+++ b/Patches/ScriptExtender/ScriptExtender.cpp
@@ -8,13 +8,14 @@
 #include "Extensions/twoDA.h"
 #include "Extensions/globalModifiers.h"
 #include "Extensions/trig.h"
+#include "Extensions/consoleCommand.h"
 
 const int TestScriptExtensionIndex = 772;
 VirtualMachineReturnTypes __stdcall ExecuteCommandTestScriptExtension(DWORD routine, int paramCount) {
-    debugLog("[PATCH] Called Test routine %d, with %i parameters", routine, paramCount);
+    debugLog("[ScriptExtender] Called Test routine %d, with %i parameters", routine, paramCount);
 
     if (paramCount != 3) {
-        debugLog("[PATCH] Expected 3 params in the function!");
+        debugLog("[ScriptExtender] Expected 3 params in the function!");
         CVirtualMachine* vm = CVirtualMachine::GetInstance();
         if (vm) {
             vm->StackPushInteger(0);
@@ -32,7 +33,7 @@ VirtualMachineReturnTypes __stdcall ExecuteCommandTestScriptExtension(DWORD rout
         return COMMAND_PARAM_ERROR;
     }
 
-    debugLog("[PATCH] Test Int %i", testInt);
+    debugLog("[ScriptExtender] Test Int %i", testInt);
 
     float testFloat;
     if (!vm->StackPopFloat(&testFloat)) {
@@ -40,7 +41,7 @@ VirtualMachineReturnTypes __stdcall ExecuteCommandTestScriptExtension(DWORD rout
         return COMMAND_PARAM_ERROR;
     }
 
-    debugLog("[PATCH] Test Float %f", testFloat);
+    debugLog("[ScriptExtender] Test Float %f", testFloat);
 
     CExoString testString;
     if (!vm->StackPopString(&testString)) {
@@ -48,7 +49,7 @@ VirtualMachineReturnTypes __stdcall ExecuteCommandTestScriptExtension(DWORD rout
         return COMMAND_PARAM_ERROR;
     }
 
-    debugLog("[PATCH] Test string \"%s\"", testString.GetCStr());
+    debugLog("[ScriptExtender] Test string \"%s\"", testString.GetCStr());
 
     if (!vm->StackPushInteger(1)) {
         delete vm;
@@ -61,7 +62,7 @@ VirtualMachineReturnTypes __stdcall ExecuteCommandTestScriptExtension(DWORD rout
 
 extern "C" void __cdecl InitializeExtensionCommands(DWORD* commands)
 {
-    debugLog("[PATCH] Initializing Extension Commands. Commands Array: %p", commands);
+    debugLog("[ScriptExtender] Initializing Extension Commands. Commands Array: %p", commands);
 
     commands[TestScriptExtensionIndex] = (DWORD)&ExecuteCommandTestScriptExtension;
 
@@ -80,7 +81,6 @@ extern "C" void __cdecl InitializeExtensionCommands(DWORD* commands)
     commands[AdjustCreatureAttributesIndex] = (DWORD)&ExecuteCommandAdjustCreatureAttributes;
     commands[AdjustCreatureSkillsIndex] = (DWORD)&ExecuteCommandAdjustCreatureSkills;
     commands[GetSkillRankBaseIndex] = (DWORD)&ExecuteCommandGetSkillRankBase;
-    debugLog("[PATCH] GetSkillRankBase at %p", &ExecuteCommandGetSkillRankBase);
 
     commands[IsRunningIndex] = (DWORD)&ExecuteCommandIsRunning;
     commands[IsStealthedIndex] = (DWORD)&ExecuteCommandIsStealthed;
@@ -97,6 +97,8 @@ extern "C" void __cdecl InitializeExtensionCommands(DWORD* commands)
     commands[cotIndex] = (DWORD)&ExecuteCommandTrig;
     commands[RadToDegIndex] = (DWORD)&ExecuteCommandRadToDeg;
     commands[DegToRadIndex] = (DWORD)&ExecuteCommandDegToRad;
+
+    commands[RunConsoleCommandIndex] = (DWORD)&ExecuteCommandRunConsoleCommand;
 }
 
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)

--- a/Patches/ScriptExtender/ScriptExtender.cpp
+++ b/Patches/ScriptExtender/ScriptExtender.cpp
@@ -9,6 +9,7 @@
 #include "Extensions/globalModifiers.h"
 #include "Extensions/trig.h"
 #include "Extensions/consoleCommand.h"
+#include "Extensions/lastTarget.h"
 
 const int TestScriptExtensionIndex = 772;
 VirtualMachineReturnTypes __stdcall ExecuteCommandTestScriptExtension(DWORD routine, int paramCount) {
@@ -99,6 +100,7 @@ extern "C" void __cdecl InitializeExtensionCommands(DWORD* commands)
     commands[DegToRadIndex] = (DWORD)&ExecuteCommandDegToRad;
 
     commands[RunConsoleCommandIndex] = (DWORD)&ExecuteCommandRunConsoleCommand;
+    commands[GetPlayerLastTargetObjectIndex] = (DWORD)&ExecuteCommandetGetPlayerLastTarget;
 }
 
 BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)

--- a/Patches/ScriptExtender/additional/nwscript.nss
+++ b/Patches/ScriptExtender/additional/nwscript.nss
@@ -5334,3 +5334,6 @@ float DegToRad(float fDegrees);
 // 799. Runs the cheat console command in sCommand as if it were input
 // into the cheat console
 string RunConsoleCommand(string sCommand);
+
+// 800. Gets the object last targeted by the player
+object GetPlayerLastTarget();

--- a/Patches/ScriptExtender/additional/nwscript.nss
+++ b/Patches/ScriptExtender/additional/nwscript.nss
@@ -5330,3 +5330,7 @@ float RadToDeg(float fRadians);
 
 // 798. Math operation: convert fDegrees to radians
 float DegToRad(float fDegrees);
+
+// 799. Runs the cheat console command in sCommand as if it were input
+// into the cheat console
+string RunConsoleCommand(string sCommand);

--- a/Patches/ScriptExtender/manifest.toml
+++ b/Patches/ScriptExtender/manifest.toml
@@ -1,7 +1,7 @@
 [patch]
 id = "script-extender"
 name = "Lane's KotOR Script Extender"
-version = "1.1.2"
+version = "1.2.0"
 author = "Lane"
 description = "Adds additional NWScript commands."
 


### PR DESCRIPTION
```
// 799. Runs the cheat console command in sCommand as if it were input
// into the cheat console
string RunConsoleCommand(string sCommand);

// 800. Gets the object last targeted by the player
object GetPlayerLastTarget();
```