### PR TITLE
add import-globals for the global_pointers table to SqliteTools

### DIFF
--- a/tools/SqliteTools/Commands/ImportGlobalsCommand.cs
+++ b/tools/SqliteTools/Commands/ImportGlobalsCommand.cs
@@ -1,0 +1,203 @@
+using Microsoft.Data.Sqlite;
+using SqliteTools.Models;
+
+namespace SqliteTools.Commands;
+
+public class ImportGlobalsCommand : ICommand
+{
+    public void Execute(string[] args)
+    {
+        var csvPath = GetArgument(args, "--csv");
+        var dbPath = GetArgument(args, "--database");
+        var mode = GetArgument(args, "--mode", "append"); // append or replace
+
+        if (string.IsNullOrEmpty(csvPath) || string.IsNullOrEmpty(dbPath))
+        {
+            Console.Error.WriteLine("Usage: SqliteTools import-globals --csv <file.csv> --database <database.db> [--mode append|replace]");
+            Environment.Exit(1);
+        }
+
+        if (!File.Exists(csvPath))
+        {
+            throw new FileNotFoundException($"CSV file not found: {csvPath}");
+        }
+
+        if (!File.Exists(dbPath))
+        {
+            throw new FileNotFoundException($"Database file not found: {dbPath}");
+        }
+
+        using var connection = new SqliteConnection($"Data Source={dbPath}");
+        connection.Open();
+
+        var records = ParseCsv(csvPath);
+
+        using var transaction = connection.BeginTransaction();
+
+        if (mode == "replace")
+        {
+            var deleteCmd = connection.CreateCommand();
+            deleteCmd.CommandText = "DELETE FROM global_pointers";
+            int deletedCount = deleteCmd.ExecuteNonQuery();
+            Console.WriteLine($"Deleted {deletedCount} existing global pointers (replace mode)");
+        }
+
+        int importedCount = 0;
+        int updatedCount = 0;
+
+        foreach (var record in records)
+        {
+            bool wasUpdate = InsertOrUpdateGlobal(connection, record);
+            if (wasUpdate)
+                updatedCount++;
+            else
+                importedCount++;
+        }
+
+        transaction.Commit();
+        Console.WriteLine($"Import complete: {importedCount} new global pointers, {updatedCount} updated");
+    }
+
+    private List<GlobalPointer> ParseCsv(string csvPath)
+    {
+        var records = new List<GlobalPointer>();
+        var lines = File.ReadAllLines(csvPath);
+
+        if (lines.Length == 0)
+        {
+            throw new InvalidDataException("CSV file is empty");
+        }
+
+        var header = ParseCsvLine(lines[0]);
+        int nameIdx = header.IndexOf("pointer_name");
+        int addrIdx = header.IndexOf("address");
+        int notesIdx = header.IndexOf("notes");
+
+        if (nameIdx == -1 || addrIdx == -1)
+        {
+            throw new InvalidDataException("CSV must have pointer_name and address columns");
+        }
+
+        for (int i = 1; i < lines.Length; i++)
+        {
+            var line = lines[i].Trim();
+            if (string.IsNullOrEmpty(line))
+                continue;
+
+            var parts = ParseCsvLine(line);
+
+            if (parts.Count < 2)
+                continue;
+
+            if (string.IsNullOrEmpty(parts[nameIdx]))
+            {
+                Console.Error.WriteLine($"Warning: Skipping line {i + 1}, empty pointer_name");
+                continue;
+            }
+
+            // Checked now so the warning can name the line it came from.
+            if (!TryParseAddress(parts[addrIdx], out _))
+            {
+                Console.Error.WriteLine($"Warning: Skipping line {i + 1}, invalid address value: {parts[addrIdx]}");
+                continue;
+            }
+
+            records.Add(new GlobalPointer
+            {
+                PointerName = parts[nameIdx],
+                Address = parts[addrIdx],
+                Notes = notesIdx >= 0 && notesIdx < parts.Count && !string.IsNullOrEmpty(parts[notesIdx])
+                    ? parts[notesIdx]
+                    : null
+            });
+        }
+
+        return records;
+    }
+
+    private List<string> ParseCsvLine(string line)
+    {
+        var result = new List<string>();
+        var current = new System.Text.StringBuilder();
+        bool inQuotes = false;
+
+        for (int i = 0; i < line.Length; i++)
+        {
+            char c = line[i];
+
+            if (c == '"')
+            {
+                inQuotes = !inQuotes;
+            }
+            else if (c == ',' && !inQuotes)
+            {
+                result.Add(current.ToString().Trim());
+                current.Clear();
+            }
+            else
+            {
+                current.Append(c);
+            }
+        }
+
+        result.Add(current.ToString().Trim());
+        return result;
+    }
+
+    private bool InsertOrUpdateGlobal(SqliteConnection conn, GlobalPointer pointer)
+    {
+        var checkCmd = conn.CreateCommand();
+        checkCmd.CommandText = "SELECT COUNT(*) FROM global_pointers WHERE pointer_name = @name";
+        checkCmd.Parameters.AddWithValue("@name", pointer.PointerName);
+        bool exists = Convert.ToInt32(checkCmd.ExecuteScalar()) > 0;
+
+        TryParseAddress(pointer.Address, out long address);
+
+        var cmd = conn.CreateCommand();
+        cmd.CommandText = @"
+            INSERT INTO global_pointers (pointer_name, address, notes)
+            VALUES (@name, @address, @notes)
+            ON CONFLICT(pointer_name) DO UPDATE SET
+                address = excluded.address,
+                notes = excluded.notes";
+
+        cmd.Parameters.AddWithValue("@name", pointer.PointerName);
+        cmd.Parameters.AddWithValue("@address", address);
+        cmd.Parameters.AddWithValue("@notes", pointer.Notes ?? (object)DBNull.Value);
+
+        cmd.ExecuteNonQuery();
+        return exists;
+    }
+
+    // Hex with an 0x prefix, or plain decimal.
+    private bool TryParseAddress(string address, out long value)
+    {
+        value = 0;
+        if (string.IsNullOrEmpty(address))
+            return false;
+
+        try
+        {
+            value = address.StartsWith("0x", StringComparison.OrdinalIgnoreCase)
+                ? Convert.ToInt64(address.Substring(2), 16)
+                : Convert.ToInt64(address);
+            return true;
+        }
+        catch (Exception e) when (e is FormatException || e is OverflowException || e is ArgumentException)
+        {
+            return false;
+        }
+    }
+
+    private string GetArgument(string[] args, string key, string defaultValue = "")
+    {
+        for (int i = 0; i < args.Length - 1; i++)
+        {
+            if (args[i] == key)
+            {
+                return args[i + 1];
+            }
+        }
+        return defaultValue;
+    }
+}

--- a/tools/SqliteTools/Models/GlobalPointer.cs
+++ b/tools/SqliteTools/Models/GlobalPointer.cs
@@ -1,0 +1,8 @@
+namespace SqliteTools.Models;
+
+public class GlobalPointer
+{
+    public string PointerName { get; set; } = string.Empty;
+    public string Address { get; set; } = string.Empty;
+    public string? Notes { get; set; }
+}

--- a/tools/SqliteTools/Program.cs
+++ b/tools/SqliteTools/Program.cs
@@ -32,6 +32,9 @@ class Program
                 case "import-vtables":
                     new ImportVtablesCommand().Execute(commandArgs);
                     break;
+                case "import-globals":
+                    new ImportGlobalsCommand().Execute(commandArgs);
+                    break;
                 case "migrate":
                     new MigrateSchemaCommand().Execute(commandArgs);
                     break;
@@ -85,6 +88,11 @@ class Program
         Console.WriteLine("      CSV columns: class_name, vtable_address (hex)");
         Console.WriteLine("      Updates only the vtable column; size/notes are preserved");
         Console.WriteLine("      Modes: append (update/insert), replace (clear vtable column first)");
+        Console.WriteLine();
+        Console.WriteLine("  import-globals --csv <file.csv> --database <database.db> [--mode append|replace]");
+        Console.WriteLine("      Import global pointers from CSV into SQLite database");
+        Console.WriteLine("      CSV columns: pointer_name, address (hex or decimal), notes");
+        Console.WriteLine("      Modes: append (update/insert), replace (delete all first)");
         Console.WriteLine();
         Console.WriteLine("  migrate --database <database.db>");
         Console.WriteLine("      Run schema migrations on database");

--- a/tools/SqliteTools/README.md
+++ b/tools/SqliteTools/README.md
@@ -73,6 +73,39 @@ Optional columns: `notes`
 
 ---
 
+### Import Global Pointers
+
+Imports global pointers from a CSV file into an existing database.
+
+```powershell
+dotnet run -- import-globals --csv "C:\path\to\globals.csv" --database "C:\path\to\database.db"
+```
+
+**With replace mode** (deletes all existing global pointers first):
+```powershell
+dotnet run -- import-globals --csv "C:\path\to\globals.csv" --database "C:\path\to\database.db" --mode replace
+```
+
+**Example:**
+```powershell
+dotnet run -- import-globals --csv "C:\Users\laned\globals.csv" --database "..\..\AddressDatabases\kotor1_0_3.db"
+```
+
+**CSV Format:**
+```csv
+pointer_name,address,notes
+APP_MANAGER_PTR,0x007A39FC,"xref-verified: StartServices (631 xrefs)"
+SCREEN_WIDTH,0x0078D1D4,
+```
+
+Required columns: `pointer_name`, `address`
+Optional columns: `notes`
+
+Addresses can be hex with a `0x` prefix, or plain decimal. A row with an address that
+will not parse, or no name, is skipped with a warning naming the line.
+
+---
+
 ### Migrate Database Schema
 
 Runs schema migrations on a database (e.g., adds new columns for Ghidra import support).


### PR DESCRIPTION
I noticed that the other tables all have a CSV importer, but the global_pointers table didn't. 

This new command works like import-offsets: same --csv, --database and --mode arguments, keyed on pointer_name so re-running updates rather than duplicates.