### PR TITLE
Linux: Fix Launching Unpatched games and make sure the custom command runs from the game directory

### DIFF
--- a/src/KPatchCore/Launcher/ConfiguredGameLauncher.cs
+++ b/src/KPatchCore/Launcher/ConfiguredGameLauncher.cs
@@ -1,0 +1,29 @@
+using KPatchCore.Models;
+
+namespace KPatchCore.Launcher;
+
+/// <summary>
+/// Launch strategy for every deployment method the manager cannot start directly. The
+/// game loads the patcher itself, through the staged KProxy under Wine or Proton and
+/// through DT_NEEDED on the native Linux build, so all this has to do is start the game
+/// the way the user configured: through Steam, or a custom command (Lutris, Heroic,
+/// plain Wine).
+/// </summary>
+internal sealed class ConfiguredGameLauncher : IGameLauncher
+{
+    private readonly LaunchConfig _config;
+
+    public ConfiguredGameLauncher(LaunchConfig config)
+    {
+        _config = config;
+    }
+
+    public LaunchResult Launch(
+        string gameExePath,
+        string dllPath,
+        string? commandLineArgs,
+        Distribution distribution)
+    {
+        return LaunchDispatcher.Start(_config, gameExePath, "The game loads the patches at startup.");
+    }
+}

--- a/src/KPatchCore/Launcher/DeploymentPolicy.cs
+++ b/src/KPatchCore/Launcher/DeploymentPolicy.cs
@@ -60,6 +60,17 @@ public static class DeploymentPolicy
     }
 
     /// <summary>
+    /// Whether the manager can start the game executable itself. Injection runs it
+    /// directly; the other methods cannot, because the executable is either a Windows
+    /// build that needs Wine or a native build Steam owns. For those the user's
+    /// configured launch method is the only way in, patched or not.
+    /// </summary>
+    public static bool HostStartsGameDirectly(DeploymentMethod deployment)
+    {
+        return deployment == DeploymentMethod.Injection;
+    }
+
+    /// <summary>
     /// The patcher runtime module the game loads for a deployment method: the native ELF
     /// maps KotorPatcher.so via DT_NEEDED, every other method loads KotorPatcher.dll. This
     /// is the single source of the .so-vs-.dll choice, shared by install staging and launch.

--- a/src/KPatchCore/Launcher/GameLauncher.cs
+++ b/src/KPatchCore/Launcher/GameLauncher.cs
@@ -34,20 +34,20 @@ public static class GameLauncher
 
         var patchConfigPath = Path.Combine(gameDir, "patch_config.toml");
 
-        // Check if patches are installed
-        if (!File.Exists(patchConfigPath))
-        {
-            return LaunchVanilla(gameExePath, commandLineArgs);
-        }
-
-        // Patches are installed. Detect the game to pick the deployment method (which decides the
-        // patcher module the game loads) and the distribution (which decides the launch strategy).
+        // Detect the game before deciding anything. The deployment method decides both the
+        // patcher module the game loads and how the game is started, and only the first of
+        // those depends on patches being installed.
         var versionResult = GameDetector.DetectVersion(gameExePath, allowManagedInstallState: true);
         var gameVersion = versionResult.Data;
         var distribution = gameVersion?.Distribution ?? Distribution.Other;
         var deployment = gameVersion != null
             ? DeploymentPolicy.ForGame(gameVersion)
             : DeploymentPolicy.ForCurrentPlatform();
+
+        if (!File.Exists(patchConfigPath))
+        {
+            return LaunchVanilla(gameExePath, commandLineArgs, launchConfig, deployment);
+        }
 
         var moduleName = DeploymentPolicy.PatcherModuleFileName(deployment);
         var patcherModulePath = Path.Combine(gameDir, moduleName);
@@ -58,7 +58,7 @@ public static class GameLauncher
                 $"Expected location: {patcherModulePath}");
         }
 
-        return Launch(gameExePath, patcherModulePath, distribution, commandLineArgs, launchConfig);
+        return Launch(gameExePath, patcherModulePath, distribution, commandLineArgs, launchConfig, deployment);
     }
 
     /// <summary>
@@ -74,7 +74,8 @@ public static class GameLauncher
         string dllPath,
         Distribution distribution,
         string? commandLineArgs = null,
-        LaunchConfig? launchConfig = null)
+        LaunchConfig? launchConfig = null,
+        DeploymentMethod? deployment = null)
     {
         // Validate inputs
         if (string.IsNullOrWhiteSpace(gameExePath) || !File.Exists(gameExePath))
@@ -88,19 +89,22 @@ public static class GameLauncher
         }
 
         // Delegate to the platform-specific launcher
-        return CreateLauncher(launchConfig).Launch(gameExePath, dllPath, commandLineArgs, distribution);
+        return CreateLauncher(launchConfig, deployment).Launch(gameExePath, dllPath, commandLineArgs, distribution);
     }
 
     /// <summary>
     /// Selects the launch strategy for the configured deployment method.
     /// </summary>
-    private static IGameLauncher CreateLauncher(LaunchConfig? launchConfig)
+    private static IGameLauncher CreateLauncher(LaunchConfig? launchConfig, DeploymentMethod? deployment)
     {
-        // Proxy method: the game loads the patcher itself via the staged proxy,
-        // so we just start it (Steam or a custom command).
-        if (DeploymentPolicy.ForCurrentPlatform() == DeploymentMethod.Proxy)
+        // Callers that never detected the game fall back to the host's default.
+        var method = deployment ?? DeploymentPolicy.ForCurrentPlatform();
+
+        // Anything the manager cannot start itself is started the way the user configured:
+        // the game loads the patcher on its own, via the staged proxy or via DT_NEEDED.
+        if (!DeploymentPolicy.HostStartsGameDirectly(method))
         {
-            return new ProxyGameLauncher(launchConfig ?? new LaunchConfig());
+            return new ConfiguredGameLauncher(launchConfig ?? new LaunchConfig());
         }
 
         // Injection only works on Windows (it uses the Win32 API).
@@ -117,13 +121,27 @@ public static class GameLauncher
     /// </summary>
     /// <param name="gameExePath">Path to game executable</param>
     /// <param name="commandLineArgs">Optional command line arguments</param>
+    /// <param name="launchConfig">How to start the game, when the host cannot run it directly</param>
+    /// <param name="deployment">The game's deployment method; defaults to the host's</param>
     /// <returns>Launch result with process information</returns>
-    public static LaunchResult LaunchVanilla(string gameExePath, string? commandLineArgs = null)
+    public static LaunchResult LaunchVanilla(
+        string gameExePath,
+        string? commandLineArgs = null,
+        LaunchConfig? launchConfig = null,
+        DeploymentMethod? deployment = null)
     {
         // Validate game path
         if (string.IsNullOrWhiteSpace(gameExePath) || !File.Exists(gameExePath))
         {
             return LaunchResult.Fail($"Game executable not found: {gameExePath}");
+        }
+
+        // Whether the game is patched changes what gets loaded into it, not how it is
+        // started, so an unpatched launch asks the same question a patched one does.
+        if (!DeploymentPolicy.HostStartsGameDirectly(deployment ?? DeploymentPolicy.ForCurrentPlatform()))
+        {
+            return LaunchDispatcher.Start(
+                launchConfig ?? new LaunchConfig(), gameExePath, "No patches are installed.");
         }
 
         try

--- a/src/KPatchCore/Launcher/LaunchDispatcher.cs
+++ b/src/KPatchCore/Launcher/LaunchDispatcher.cs
@@ -1,37 +1,28 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
-using KPatchCore.Models;
 
 namespace KPatchCore.Launcher;
 
 /// <summary>
-/// Launch strategy for the proxy deployment method. The staged KProxy loads the
-/// patcher when the game starts, so this just starts the game the way the user
-/// configured: through Steam, or a custom command (Lutris, Heroic, plain Wine).
-/// Used wherever the deployment method is proxy (Linux today, or Windows if wired
-/// onto it via <see cref="DeploymentPolicy"/>).
+/// Starts the game the way the user configured it: through Steam, or a custom command
+/// (Lutris, Heroic, plain Wine). This is the single place that turns a
+/// <see cref="LaunchConfig"/> into a running game, shared by the patched and unpatched
+/// paths so a launch behaves the same either way.
 /// </summary>
-internal sealed class ProxyGameLauncher : IGameLauncher
+internal static class LaunchDispatcher
 {
-    private readonly LaunchConfig _config;
-
-    public ProxyGameLauncher(LaunchConfig config)
+    /// <summary>
+    /// Starts the game per <paramref name="config"/>. Returns why it could not rather
+    /// than throwing.
+    /// </summary>
+    public static LaunchResult Start(LaunchConfig config, string gameExePath, string context)
     {
-        _config = config;
+        return config.Method == LaunchMethod.Custom
+            ? Custom(config, gameExePath, context)
+            : Steam(gameExePath, context);
     }
 
-    public LaunchResult Launch(
-        string gameExePath,
-        string dllPath,
-        string? commandLineArgs,
-        Distribution distribution)
-    {
-        return _config.Method == LaunchMethod.Custom
-            ? LaunchCustom(gameExePath)
-            : LaunchSteam(gameExePath);
-    }
-
-    private LaunchResult LaunchSteam(string gameExePath)
+    private static LaunchResult Steam(string gameExePath, string context)
     {
         if (!SteamLauncher.TryResolveAppId(gameExePath, out var appId))
         {
@@ -43,8 +34,7 @@ internal sealed class ProxyGameLauncher : IGameLauncher
         try
         {
             SteamLauncher.Launch(appId);
-            return LaunchResult.Launched(
-                $"Launched through Steam (app {appId}). Patches load via the KProxy.");
+            return LaunchResult.Launched($"Launched through Steam (app {appId}). {context}");
         }
         catch (Exception ex)
         {
@@ -52,14 +42,19 @@ internal sealed class ProxyGameLauncher : IGameLauncher
         }
     }
 
-    private LaunchResult LaunchCustom(string gameExePath)
+    private static LaunchResult Custom(LaunchConfig config, string gameExePath, string context)
     {
-        if (string.IsNullOrWhiteSpace(_config.CustomCommand))
+        if (string.IsNullOrWhiteSpace(config.CustomCommand))
         {
             return LaunchResult.Fail("No custom launch command is set.");
         }
 
-        var command = _config.CustomCommand.Replace("{exe}", gameExePath);
+        var command = config.CustomCommand.Replace("{exe}", gameExePath);
+
+        // KOTOR resolves chitin.key and the override directory relative to the working
+        // directory, so it has to start in the game folder. A wrapper like "wine {exe}"
+        // would otherwise inherit the manager's own directory and the game exits early.
+        var gameDir = Path.GetDirectoryName(gameExePath);
 
         // A user-typed command line (wrappers, extra args, quoting), so hand it to the
         // platform's command processor. .NET has no native command-line runner, and
@@ -82,10 +77,15 @@ internal sealed class ProxyGameLauncher : IGameLauncher
             return LaunchResult.Fail("Custom launch is only supported on Windows and Linux.");
         }
 
+        if (!string.IsNullOrWhiteSpace(gameDir))
+        {
+            startInfo.WorkingDirectory = gameDir;
+        }
+
         try
         {
             Process.Start(startInfo);
-            return LaunchResult.Launched("Launched with the custom command. Patches load via the KProxy.");
+            return LaunchResult.Launched($"Launched with the custom command. {context}");
         }
         catch (Exception ex)
         {

--- a/src/KPatchLauncher/ViewModels/MainViewModel.cs
+++ b/src/KPatchLauncher/ViewModels/MainViewModel.cs
@@ -194,12 +194,13 @@ public class MainViewModel : ViewModelBase
     }
 
     /// <summary>
-    /// Whether the launch-method controls apply. Only the proxy deployment method
-    /// reads them (Steam or a custom command); the injection method ignores launch
-    /// config, so they stay hidden there.
+    /// Whether the launch-method controls apply. They are read wherever the manager
+    /// cannot start the game itself and the user's choice of Steam or a custom command
+    /// is what actually starts it. Injection runs the executable directly and ignores
+    /// them, so they stay hidden there.
     /// </summary>
     public bool ShowLaunchSettings =>
-        DeploymentPolicy.ForCurrentPlatform() == DeploymentMethod.Proxy;
+        !DeploymentPolicy.HostStartsGameDirectly(DeploymentPolicy.ForCurrentPlatform());
 
     /// <summary>
     /// When true, the game is launched with <see cref="CustomLaunchCommand"/>


### PR DESCRIPTION
This fixes launching the game with a custom command (e.g. `wine {exe}`), as well properly handling unpatched game launching on Linux.

Previously it would attempt to run the game from the current working directory (wherever Kotor Patch Manager was) now it will run that command from the game directory. I ran into this when developing the Kotor Driver Compat patch.

Unpatched games will also properly run. On Windows you can just call on the game binary and it runs, on Linux we need to run via Proton or Wine (or the Steam Linux Runtime for the native K2 version) so it needs to run via Steam or the custom command to properly run.