### PR TITLE
C# Groundwork for macOS, and the library proxy on Windows

### DIFF
--- a/docs/NATIVE_LINUX.md
+++ b/docs/NATIVE_LINUX.md
@@ -18,7 +18,7 @@ The manager has three ways to load `KotorPatcher` into a game, chosen by
 |-------------|----------------------------|-------------------------------------------|
 | `Injection` | Windows PE (native)        | Manager injects `KotorPatcher.dll`        |
 | `Proxy`     | Windows PE under Wine/Proton | Staged KProxy loads `KotorPatcher.dll`    |
-| `ElfNeeded` | Native Linux ELF           | Loader maps `KotorPatcher.so` via DT_NEEDED |
+| `LinkedDependency` | Native Linux ELF           | Loader maps `KotorPatcher.so` via DT_NEEDED |
 
 For the native ELF the manager adds `KotorPatcher.so` to the game
 executable's `DT_NEEDED` list. The dynamic loader then maps it at startup,

--- a/publish.bat
+++ b/publish.bat
@@ -43,6 +43,19 @@ if exist "lib\sqlite3.dll" (
     echo   [ERROR] lib\sqlite3.dll not found - GameAPI patches will fail at runtime
 )
 
+REM Stage the KProxy. It takes the place of the game's binkw32.dll when the user
+REM picks the library proxy under Options, and the manager copies it from here into
+REM the game directory at install time. There is no MSVC project for it, only
+REM src\KProxy\build-mingw.sh, so it is staged when a build has produced it and
+REM the release goes out without the proxy option working when it has not.
+if exist "bin\Release\binkw32.dll" (
+    copy /Y "bin\Release\binkw32.dll" "%RELEASE_DIR%\bin\" >nul
+    echo   [OK] binkw32.dll staged ^(KProxy^)
+) else (
+    echo   [WARN] binkw32.dll not found in bin\Release\
+    echo          Options ^> "Use library proxy" will have nothing to stage.
+)
+
 REM Build launcher
 echo [2/5] Building KPatchLauncher...
 cd src\KPatchLauncher
@@ -96,7 +109,9 @@ set "README_FILE=%RELEASE_DIR%\README.txt"
   echo.
   echo Contents:
   echo   bin/KPatchLauncher.exe - Main application
-  echo   bin/KotorPatcher.dll   - Runtime patcher (injected into the game)
+  echo   bin/KotorPatcher.dll   - Runtime patcher loaded into the game
+  echo   bin/binkw32.dll        - KProxy: loads the patcher when the game starts,
+  echo                            used when Options ^> "Use library proxy" is on
   echo   bin/sqlite3.dll        - Address database access for GameAPI patch DLLs
   echo   tools/create-patch.bat - Patch creation tool
   echo   patches/ - pre-built patches I've been developing with this project
@@ -107,6 +122,12 @@ set "README_FILE=%RELEASE_DIR%\README.txt"
   echo   2. Point to your KOTOR installation
   echo   3. Point to your patch directory of choice
   echo   4. Apply and enjoy!
+  echo.
+  echo Deployment ^(Options menu^):
+  echo   unchecked - the manager starts the game and injects the patcher
+  echo   checked   - KProxy replaces the game's binkw32.dll and loads the patcher
+  echo               itself; the original is kept as binkw32Hooked.dll
+  echo   The choice is locked while patches are installed.
   echo.
   echo Created by Lane (Discord: @lane_d)
 )

--- a/publish.sh
+++ b/publish.sh
@@ -235,6 +235,7 @@ KotOR Patch Manager v$VERSION (Linux)
 Contents:
   bin/KPatchLauncher     - Main application (native linux-x64)
   bin/KotorPatcher.dll   - Runtime patcher (loaded inside the game under Wine)
+  bin/KotorPatcher.so    - Runtime patcher for the native Linux build of KOTOR II
   bin/binkw32.dll        - KProxy: loads the patcher when the game starts
   bin/sqlite3.dll        - Address database access for patch DLLs (Wine side)
   tools/create-patch.py  - Patch creation tool (needs MinGW-w64 for DETOUR patches)
@@ -245,8 +246,11 @@ Quick Start:
   1. Run bin/KPatchLauncher
   2. Point to your KOTOR installation (Steam/GOG under Wine or Proton)
   3. Point to your patch directory of choice
-  4. Apply, then launch through Steam or a custom command. Patches load via the
-     KProxy (it replaces binkw32.dll; the original is kept as binkw32Hooked.dll).
+  4. Apply, then launch through Steam or a custom command. For a Windows build
+     under Wine or Proton the KProxy loads the patches (it replaces binkw32.dll;
+     the original is kept as binkw32Hooked.dll). The native Linux build of
+     KOTOR II instead names KotorPatcher.so in its own dependency list, so the
+     loader maps it at startup.
 
 Created by Lane (Discord: @lane_d)
 EOF

--- a/src/KPatchCore/Applicators/ElfDependencies.cs
+++ b/src/KPatchCore/Applicators/ElfDependencies.cs
@@ -4,19 +4,25 @@ using LibObjectFile.Elf;
 namespace KPatchCore.Applicators;
 
 /// <summary>
-/// Injects a DT_NEEDED dependency on the native patcher module (KotorPatcher.so) into a
-/// dynamically-linked ELF game executable, so the dynamic loader maps it at startup. This is the
-/// native Linux counterpart to staging the KProxy DLL on Windows. The edit is address-preserving
-/// (LibObjectFile relocates .dynamic/.dynstr and repurposes a PT_NOTE into a PT_LOAD), so existing
-/// code, symbols and relocations stay valid.
+/// The DT_NEEDED list of a dynamically-linked ELF. The edit is address-preserving: LibObjectFile
+/// relocates .dynamic and .dynstr and repurposes a PT_NOTE into a PT_LOAD rather than shifting
+/// what is already there, so existing code, symbols and relocations stay valid.
 /// </summary>
-public static class ElfInjector
+internal sealed class ElfDependencies : IExecutableDependencies
 {
+    private readonly string _elfPath;
+
+    public ElfDependencies(string elfPath) => _elfPath = elfPath;
+
+    public PatchResult<bool> Contains(string moduleName) => IsNeeded(_elfPath, moduleName);
+
+    public PatchResult Add(string moduleName) => AddNeeded(_elfPath, moduleName);
+
     /// <summary>
     /// Reports whether <paramref name="soName"/> is already a DT_NEEDED dependency of the ELF at
     /// <paramref name="elfPath"/>. Fails if the file is missing, unreadable, or not dynamically linked.
     /// </summary>
-    public static PatchResult<bool> IsNeeded(string elfPath, string soName)
+    private static PatchResult<bool> IsNeeded(string elfPath, string soName)
     {
         if (!File.Exists(elfPath))
             return PatchResult<bool>.Fail($"Executable not found: {elfPath}");
@@ -45,7 +51,7 @@ public static class ElfInjector
     /// through a sibling temp file that is then swapped in, so a failed write never leaves a corrupt
     /// executable on disk (the caller has also backed the exe up before this runs).
     /// </summary>
-    public static PatchResult AddNeeded(string elfPath, string soName)
+    private static PatchResult AddNeeded(string elfPath, string soName)
     {
         if (string.IsNullOrWhiteSpace(elfPath))
             return PatchResult.Fail("Executable path cannot be null or empty");

--- a/src/KPatchCore/Applicators/ExecutableDependencies.cs
+++ b/src/KPatchCore/Applicators/ExecutableDependencies.cs
@@ -1,0 +1,53 @@
+using KPatchCore.Models;
+using KPatchCore.Parsers;
+
+namespace KPatchCore.Applicators;
+
+/// <summary>
+/// The list of libraries an executable asks its dynamic loader to map at startup, and the ability
+/// to add to it. Naming the patcher there is what makes it load with no injector and no proxy,
+/// whoever starts the game.
+/// </summary>
+/// <remarks>
+/// There is deliberately no removal. Uninstall restores the executable from the backup taken
+/// before it was touched, which undoes the edit byte for byte. A separate strip would be a second,
+/// lossier undo of the same thing.
+/// </remarks>
+public interface IExecutableDependencies
+{
+    /// <summary>Whether <paramref name="moduleName"/> is already in the executable's list.</summary>
+    PatchResult<bool> Contains(string moduleName);
+
+    /// <summary>
+    /// Adds <paramref name="moduleName"/> to the list. Idempotent: a module already present leaves
+    /// the file untouched. The edit preserves every existing address, so code patched beforehand
+    /// stays valid.
+    /// </summary>
+    PatchResult Add(string moduleName);
+}
+
+/// <summary>
+/// Opens an executable's dependency list using the right mechanism for its format. This is the one
+/// place that choice is made, so callers stay format-agnostic.
+/// </summary>
+public static class ExecutableDependencies
+{
+    public static PatchResult<IExecutableDependencies> Open(string exePath)
+    {
+        var format = ExecutableFormatDetector.Detect(exePath);
+        if (!format.Success)
+            return PatchResult<IExecutableDependencies>.Fail(format.Error!);
+
+        return format.Data switch
+        {
+            ExecutableFormat.Elf => PatchResult<IExecutableDependencies>.Ok(new ElfDependencies(exePath)),
+
+            // A PE's import table cannot be grown without moving what follows it, and a packed
+            // executable would not honour the edit anyway. Windows reaches the same end through
+            // DeploymentMethod.LibraryProxy instead.
+            _ => PatchResult<IExecutableDependencies>.Fail(
+                $"{Path.GetFileName(exePath)} is a {format.Data} executable, which does not support " +
+                $"adding a dependency."),
+        };
+    }
+}

--- a/src/KPatchCore/Applicators/PatchApplicator.cs
+++ b/src/KPatchCore/Applicators/PatchApplicator.cs
@@ -519,10 +519,10 @@ public class PatchApplicator
             // Step 6.5: Copy address database to game directory
             messages.Add("Step 6.5/8: Copying address database...");
 
-            // Find AddressDatabases directory in same directory as executing assembly
-            // (copied there by build system via .csproj)
-            var assemblyDir = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location) ?? string.Empty;
-            var addressDbSourceDirNormalized = Path.Combine(assemblyDir, "AddressDatabases");
+            // Find AddressDatabases beside the running application (put there by the build).
+            // Assembly.Location is empty in a single-file build, which is what Windows ships, and
+            // the lookup then resolved against the working directory instead of the install.
+            var addressDbSourceDirNormalized = Path.Combine(AppContext.BaseDirectory, "AddressDatabases");
 
             if (!Directory.Exists(addressDbSourceDirNormalized))
             {

--- a/src/KPatchCore/Applicators/PatchApplicator.cs
+++ b/src/KPatchCore/Applicators/PatchApplicator.cs
@@ -49,7 +49,7 @@ public class PatchApplicator
 
         /// <summary>
         /// Path to KotorPatcher.so to stage in the game directory when the detected game
-        /// is a native Linux ELF (DeploymentMethod.ElfNeeded). Ignored otherwise.
+        /// is a native Linux ELF (DeploymentMethod.LinkedDependency). Ignored otherwise.
         /// </summary>
         public string? PatcherSoPath { get; init; }
     }
@@ -107,7 +107,7 @@ public class PatchApplicator
     private static PatcherModule ResolvePatcherModule(DeploymentMethod deployment, InstallOptions options)
     {
         var fileName = DeploymentPolicy.PatcherModuleFileName(deployment);
-        return deployment == DeploymentMethod.ElfNeeded
+        return deployment == DeploymentMethod.LinkedDependency
             ? new PatcherModule(fileName, options.PatcherSoPath, NeedsSqlite: false)
             : new PatcherModule(fileName, options.PatcherDllPath, NeedsSqlite: true);
     }
@@ -380,7 +380,7 @@ public class PatchApplicator
             }
 
             // Step 4.6: on a native Linux ELF, add KotorPatcher.so to the game's DT_NEEDED list.
-            if (deployment == DeploymentMethod.ElfNeeded)
+            if (deployment == DeploymentMethod.LinkedDependency)
             {
                 messages.Add("Step 4.6/8: Adding KotorPatcher.so to the game's DT_NEEDED...");
                 var injectResult = ElfInjector.AddNeeded(options.GameExePath, "KotorPatcher.so");
@@ -693,7 +693,7 @@ public class PatchApplicator
             // Step 7.5: for the proxy deployment method, stage the KProxy so
             // the game loads KotorPatcher when it starts (injection does not).
             var proxyInstalled = false;
-            if (deployment == DeploymentMethod.Proxy)
+            if (deployment == DeploymentMethod.LibraryProxy)
             {
                 if (string.IsNullOrEmpty(options.ProxyDllPath))
                 {
@@ -734,7 +734,7 @@ public class PatchApplicator
                 gameVersion,
                 installOrder,
                 proxyInstalled,
-                elfNeededInstalled: deployment == DeploymentMethod.ElfNeeded);
+                linkedDependencyInstalled: deployment == DeploymentMethod.LinkedDependency);
             if (stateResult.Success)
             {
                 messages.Add($"  {stateResult.Messages.FirstOrDefault() ?? "Managed install state saved"}");

--- a/src/KPatchCore/Applicators/PatchApplicator.cs
+++ b/src/KPatchCore/Applicators/PatchApplicator.cs
@@ -382,11 +382,18 @@ public class PatchApplicator
                 messages.Add("  No static hooks to apply");
             }
 
-            // Step 4.6: on a native Linux ELF, add KotorPatcher.so to the game's DT_NEEDED list.
+            // Step 4.6: name the patcher in the executable's own dependency list, so the loader
+            // maps it at startup. This runs after the static hooks because the edit preserves
+            // existing addresses, which keeps the patched code valid.
             if (deployment == DeploymentMethod.LinkedDependency)
             {
-                messages.Add("Step 4.6/8: Adding KotorPatcher.so to the game's DT_NEEDED...");
-                var injectResult = ElfInjector.AddNeeded(options.GameExePath, "KotorPatcher.so");
+                var linkedModule = DeploymentPolicy.PatcherModuleFileName(deployment);
+                messages.Add($"Step 4.6/8: Adding {linkedModule} to the game's dependency list...");
+
+                var dependencies = ExecutableDependencies.Open(options.GameExePath);
+                var injectResult = dependencies.Success && dependencies.Data != null
+                    ? dependencies.Data.Add(linkedModule)
+                    : PatchResult.Fail(dependencies.Error!);
                 if (!injectResult.Success)
                 {
                     if (backup != null)
@@ -397,14 +404,14 @@ public class PatchApplicator
                     return new InstallResult
                     {
                         Success = false,
-                        Error = $"Failed to add KotorPatcher.so to the game ELF: {injectResult.Error}",
+                        Error = $"Failed to add {linkedModule} to the game executable: {injectResult.Error}",
                         DetectedVersion = gameVersion,
                         Backup = backup,
                         Messages = messages
                     };
                 }
 
-                messages.Add($"  {injectResult.Messages.FirstOrDefault() ?? "DT_NEEDED updated"}");
+                messages.Add($"  {injectResult.Messages.FirstOrDefault() ?? "Dependency list updated"}");
             }
 
             // Step 5: Extract patch DLLs (for DETOUR hooks and DLL-only patches)

--- a/src/KPatchCore/Applicators/PatchApplicator.cs
+++ b/src/KPatchCore/Applicators/PatchApplicator.cs
@@ -35,23 +35,12 @@ public class PatchApplicator
         public bool CreateBackup { get; init; } = true;
 
         /// <summary>
-        /// Path to KotorPatcher.dll (if null, assumes it's in same directory as game exe)
+        /// Directory holding the patcher modules and the proxy library, which is where the
+        /// launcher itself runs from. Which of them gets staged is the deployment method's
+        /// decision, so a new platform adds a file here rather than a field to this type.
+        /// Null means they are expected to be in the game directory already.
         /// </summary>
-        public string? PatcherDllPath { get; init; }
-
-        /// <summary>
-        /// Path to the KProxy (binkw32.dll) to stage when deploying via proxy
-        /// so the game loads KotorPatcher under Wine/Proton.
-        /// Ignored on Windows (live injection).
-        /// If null on Linux, DLL-based patches won't load under Wine.
-        /// </summary>
-        public string? ProxyDllPath { get; init; }
-
-        /// <summary>
-        /// Path to KotorPatcher.so to stage in the game directory when the detected game
-        /// is a native Linux ELF (DeploymentMethod.LinkedDependency). Ignored otherwise.
-        /// </summary>
-        public string? PatcherSoPath { get; init; }
+        public string? PatcherDirectory { get; init; }
     }
 
     /// <summary>
@@ -107,9 +96,23 @@ public class PatchApplicator
     private static PatcherModule ResolvePatcherModule(DeploymentMethod deployment, InstallOptions options)
     {
         var fileName = DeploymentPolicy.PatcherModuleFileName(deployment);
-        return deployment == DeploymentMethod.LinkedDependency
-            ? new PatcherModule(fileName, options.PatcherSoPath, NeedsSqlite: false)
-            : new PatcherModule(fileName, options.PatcherDllPath, NeedsSqlite: true);
+        // sqlite3.dll ships beside the Windows engine for the patch DLLs' GameVersion lookups.
+        // The native engine links no sqlite, so nothing travels with it.
+        var needsSqlite = deployment != DeploymentMethod.LinkedDependency;
+        return new PatcherModule(fileName, ResolveStagedFile(options.PatcherDirectory, fileName), needsSqlite);
+    }
+
+    /// <summary>
+    /// The full path to a file the launcher would stage, or null when it is not there. Callers
+    /// treat null as "not shipped with this build" and warn rather than fail.
+    /// </summary>
+    private static string? ResolveStagedFile(string? patcherDirectory, string fileName)
+    {
+        if (string.IsNullOrEmpty(patcherDirectory))
+            return null;
+
+        var path = Path.Combine(patcherDirectory, fileName);
+        return File.Exists(path) ? path : null;
     }
 
     /// <summary>
@@ -695,7 +698,8 @@ public class PatchApplicator
             var proxyInstalled = false;
             if (deployment == DeploymentMethod.LibraryProxy)
             {
-                if (string.IsNullOrEmpty(options.ProxyDllPath))
+                var proxyPath = ResolveStagedFile(options.PatcherDirectory, DeploymentPolicy.ProxyLibraryFileName);
+                if (string.IsNullOrEmpty(proxyPath))
                 {
                     // Without the proxy staged nothing loads KotorPatcher, so DLL
                     // (DETOUR) patches won't take effect. Static patches still do.
@@ -704,7 +708,7 @@ public class PatchApplicator
                 }
                 else
                 {
-                    var proxyResult = KProxyInstaller.Install(gameDir, options.ProxyDllPath);
+                    var proxyResult = KProxyInstaller.Install(gameDir, proxyPath);
                     if (!proxyResult.Success)
                     {
                         // Undo any half-done rename before rolling back the executable.

--- a/src/KPatchCore/Launcher/DeploymentPolicy.cs
+++ b/src/KPatchCore/Launcher/DeploymentPolicy.cs
@@ -97,4 +97,11 @@ public static class DeploymentPolicy
             ? "KotorPatcher.so"
             : "KotorPatcher.dll";
     }
+
+    /// <summary>
+    /// The library <see cref="DeploymentMethod.LibraryProxy"/> stands in for. KOTOR 1 and 2 both
+    /// import binkw32.dll and Wine has no builtin, so the game's own loader picks up whatever sits
+    /// under that name in the game directory.
+    /// </summary>
+    public const string ProxyLibraryFileName = "binkw32.dll";
 }

--- a/src/KPatchCore/Launcher/DeploymentPolicy.cs
+++ b/src/KPatchCore/Launcher/DeploymentPolicy.cs
@@ -48,18 +48,52 @@ public enum DeploymentMethod
 public static class DeploymentPolicy
 {
     /// <summary>
-    /// The deployment method for the current platform. Linux must use the proxy
-    /// (native injection can't reach a Wine process); Windows uses injection.
+    /// Whether to reach the game through <see cref="DeploymentMethod.LibraryProxy"/> where
+    /// injection would otherwise be used. Process-wide configuration, set from the user's saved
+    /// settings at startup and whenever they change it. Linux is on the proxy either way, so this
+    /// only decides anything on Windows.
     /// </summary>
     /// <remarks>
-    /// To have Windows use the KProxy too, return
-    /// <see cref="DeploymentMethod.LibraryProxy"/> here. Nothing else is platform-gated.
+    /// Switching this while patches are installed would leave the game staged for the method it
+    /// was installed with, so callers gate the change on there being nothing installed.
+    /// </remarks>
+    public static bool PreferLibraryProxy { get; set; }
+
+    /// <summary>
+    /// The deployment method for the current platform. Linux must use the proxy, since native
+    /// injection cannot reach a Wine process; Windows injects unless asked for the proxy.
+    /// </summary>
+    /// <remarks>
+    /// Windows follows <see cref="PreferLibraryProxy"/>. Nothing else is platform-gated.
     /// </remarks>
     public static DeploymentMethod ForCurrentPlatform()
     {
-        return RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+        // Linux has no choice: a native process cannot inject into the Wine process running the
+        // game, so the proxy is the only way in. Windows can do either.
+        return RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || PreferLibraryProxy
             ? DeploymentMethod.LibraryProxy
             : DeploymentMethod.RuntimeInjection;
+    }
+
+    /// <summary>
+    /// Whether the deployment method is the user's to pick for a given game. It is a choice only
+    /// where both candidates are open.
+    /// </summary>
+    /// <remarks>
+    /// The host has to be able to inject, which means Windows; elsewhere the proxy is the only way
+    /// in whatever the user would prefer. The game also has to be one the host default applies to.
+    /// A native build settles the question itself by naming the patcher in its own dependency
+    /// list, and no preference changes that. A null game is treated as a choice, since nothing
+    /// about an unrecognised executable rules the host default out.
+    /// </remarks>
+    public static bool HasDeploymentChoice(GameVersion? gameVersion)
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return false;
+        }
+
+        return gameVersion is null || gameVersion.Platform == Platform.Windows;
     }
 
     /// <summary>

--- a/src/KPatchCore/Launcher/DeploymentPolicy.cs
+++ b/src/KPatchCore/Launcher/DeploymentPolicy.cs
@@ -76,14 +76,18 @@ public static class DeploymentPolicy
     }
 
     /// <summary>
-    /// Whether the manager can start the game executable itself. Injection runs it
-    /// directly; the other methods cannot, because the executable is either a Windows
-    /// build that needs Wine or a native build Steam owns. For those the user's
-    /// configured launch method is the only way in, patched or not.
+    /// Whether the manager can start the game executable itself, rather than handing off to Steam
+    /// or a user-supplied command.
     /// </summary>
-    public static bool HostStartsGameDirectly(DeploymentMethod deployment)
+    /// <remarks>
+    /// This is a question about the host, not about the deployment method. A Windows host runs a
+    /// Windows game directly whatever loads the patcher into it, which is what injection has
+    /// always done. Everywhere else the executable is either a Windows build that needs Wine or a
+    /// native build Steam owns, so the user's configured launch method is the only way in.
+    /// </remarks>
+    public static bool CanStartGameDirectly()
     {
-        return deployment == DeploymentMethod.RuntimeInjection;
+        return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
     }
 
     /// <summary>

--- a/src/KPatchCore/Launcher/DeploymentPolicy.cs
+++ b/src/KPatchCore/Launcher/DeploymentPolicy.cs
@@ -6,22 +6,38 @@ namespace KPatchCore.Launcher;
 /// <summary>
 /// How KotorPatcher gets loaded into the game.
 /// </summary>
+/// <remarks>
+/// Two of these have the game's own dynamic loader do the work, and they differ only in the
+/// mechanism the executable format offers. <see cref="LinkedDependency"/> edits the executable's
+/// dependency list, which is what ELF and Mach-O allow cheaply. <see cref="LibraryProxy"/> leaves
+/// the executable alone and replaces a library it already loads, which is the answer wherever
+/// editing that list is not an option. A packed executable is the case that forces it: the
+/// SteamStub build of KOTOR 1 does not run the image sitting on disk, so nothing written there
+/// would take effect. <see cref="RuntimeInjection"/> is the odd one out, changing nothing about
+/// the game and requiring the launcher to be what starts it.
+/// </remarks>
 public enum DeploymentMethod
 {
-    /// <summary>Runtime DLL injection into the launched process.</summary>
-    Injection,
+    /// <summary>
+    /// The launcher starts the game and writes the patcher into the live process. Win32 only,
+    /// and only available when the launcher is what started the game.
+    /// </summary>
+    RuntimeInjection,
 
     /// <summary>
-    /// The KProxy loads the patcher when the game starts. Works under
-    /// Wine/Proton, and on Windows too.
+    /// A library the game already loads is replaced with one of ours, which loads the patcher and
+    /// forwards every call on to the original. The executable is untouched, so this survives
+    /// packing and works under Wine/Proton. KProxy is the implementation, standing in for
+    /// binkw32.dll.
     /// </summary>
-    Proxy,
+    LibraryProxy,
 
     /// <summary>
-    /// KotorPatcher.so is added to the native Linux game ELF's DT_NEEDED list, so
-    /// the dynamic loader maps it at startup. No injector or proxy needed.
+    /// The patcher is named in the executable's own list of libraries to load, so the dynamic
+    /// loader maps it at startup with no injector or proxy involved. That list is DT_NEEDED on
+    /// ELF and LC_LOAD_DYLIB on Mach-O.
     /// </summary>
-    ElfNeeded,
+    LinkedDependency,
 }
 
 /// <summary>
@@ -37,25 +53,25 @@ public static class DeploymentPolicy
     /// </summary>
     /// <remarks>
     /// To have Windows use the KProxy too, return
-    /// <see cref="DeploymentMethod.Proxy"/> here. Nothing else is platform-gated.
+    /// <see cref="DeploymentMethod.LibraryProxy"/> here. Nothing else is platform-gated.
     /// </remarks>
     public static DeploymentMethod ForCurrentPlatform()
     {
         return RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
-            ? DeploymentMethod.Proxy
-            : DeploymentMethod.Injection;
+            ? DeploymentMethod.LibraryProxy
+            : DeploymentMethod.RuntimeInjection;
     }
 
     /// <summary>
-    /// The deployment method for a specific detected game. A native Linux ELF uses
-    /// <see cref="DeploymentMethod.ElfNeeded"/> (the loader maps the patcher via
-    /// DT_NEEDED); everything else is a Windows PE and falls back to the host default
-    /// (proxy under Wine/Proton, injection on Windows).
+    /// The deployment method for a specific detected game. A game whose executable can name the
+    /// patcher in its own dependency list uses <see cref="DeploymentMethod.LinkedDependency"/>.
+    /// Everything else is a Windows PE and falls back to the host default, which is the proxy
+    /// under Wine or Proton and injection on Windows.
     /// </summary>
     public static DeploymentMethod ForGame(GameVersion gameVersion)
     {
         return gameVersion.Platform == Platform.Linux
-            ? DeploymentMethod.ElfNeeded
+            ? DeploymentMethod.LinkedDependency
             : ForCurrentPlatform();
     }
 
@@ -67,17 +83,17 @@ public static class DeploymentPolicy
     /// </summary>
     public static bool HostStartsGameDirectly(DeploymentMethod deployment)
     {
-        return deployment == DeploymentMethod.Injection;
+        return deployment == DeploymentMethod.RuntimeInjection;
     }
 
     /// <summary>
-    /// The patcher runtime module the game loads for a deployment method: the native ELF
-    /// maps KotorPatcher.so via DT_NEEDED, every other method loads KotorPatcher.dll. This
-    /// is the single source of the .so-vs-.dll choice, shared by install staging and launch.
+    /// The patcher runtime module the game loads for a deployment method. This is the single
+    /// source of that choice, shared by install staging and launch, so a new platform adds its
+    /// module here rather than at each call site.
     /// </summary>
     public static string PatcherModuleFileName(DeploymentMethod deployment)
     {
-        return deployment == DeploymentMethod.ElfNeeded
+        return deployment == DeploymentMethod.LinkedDependency
             ? "KotorPatcher.so"
             : "KotorPatcher.dll";
     }

--- a/src/KPatchCore/Launcher/DirectGameLauncher.cs
+++ b/src/KPatchCore/Launcher/DirectGameLauncher.cs
@@ -1,0 +1,22 @@
+using KPatchCore.Models;
+
+namespace KPatchCore.Launcher;
+
+/// <summary>
+/// Launch strategy for a host that can run the game executable itself while something other than
+/// injection loads the patcher. That is Windows with <see cref="DeploymentMethod.LibraryProxy"/>:
+/// the staged KProxy loads the patcher when the game starts, so the manager only has to start it,
+/// the same way injection always has.
+/// </summary>
+internal sealed class DirectGameLauncher : IGameLauncher
+{
+    public LaunchResult Launch(
+        string gameExePath,
+        string dllPath,
+        string? commandLineArgs,
+        Distribution distribution)
+    {
+        return LaunchDispatcher.StartDirectly(
+            gameExePath, commandLineArgs, "The game loads the patches at startup.");
+    }
+}

--- a/src/KPatchCore/Launcher/DirectGameLauncher.cs
+++ b/src/KPatchCore/Launcher/DirectGameLauncher.cs
@@ -17,6 +17,6 @@ internal sealed class DirectGameLauncher : IGameLauncher
         Distribution distribution)
     {
         return LaunchDispatcher.StartDirectly(
-            gameExePath, commandLineArgs, "The game loads the patches at startup.");
+            gameExePath, commandLineArgs, "The game loads the patches at startup.", patched: true);
     }
 }

--- a/src/KPatchCore/Launcher/GameLauncher.cs
+++ b/src/KPatchCore/Launcher/GameLauncher.cs
@@ -136,7 +136,7 @@ public static class GameLauncher
         // Whether the game is patched changes what gets loaded into it, not how it is
         // started, so an unpatched launch asks the same question a patched one does.
         return DeploymentPolicy.CanStartGameDirectly()
-            ? LaunchDispatcher.StartDirectly(gameExePath, commandLineArgs, "No patches are installed.")
+            ? LaunchDispatcher.StartDirectly(gameExePath, commandLineArgs, "No patches are installed.", patched: false)
             : LaunchDispatcher.Start(launchConfig ?? new LaunchConfig(), gameExePath, "No patches are installed.");
     }
 }

--- a/src/KPatchCore/Launcher/GameLauncher.cs
+++ b/src/KPatchCore/Launcher/GameLauncher.cs
@@ -46,7 +46,7 @@ public static class GameLauncher
 
         if (!File.Exists(patchConfigPath))
         {
-            return LaunchVanilla(gameExePath, commandLineArgs, launchConfig, deployment);
+            return LaunchVanilla(gameExePath, commandLineArgs, launchConfig);
         }
 
         var moduleName = DeploymentPolicy.PatcherModuleFileName(deployment);
@@ -100,20 +100,19 @@ public static class GameLauncher
         // Callers that never detected the game fall back to the host's default.
         var method = deployment ?? DeploymentPolicy.ForCurrentPlatform();
 
-        // Anything the manager cannot start itself is started the way the user configured:
-        // the game loads the patcher on its own, via the staged proxy or via DT_NEEDED.
-        if (!DeploymentPolicy.HostStartsGameDirectly(method))
+        // Injection has to create the process itself, and it uses the Win32 API to do it.
+        if (method == DeploymentMethod.RuntimeInjection)
         {
-            return new ConfiguredGameLauncher(launchConfig ?? new LaunchConfig());
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                ? new WindowsGameInjector()
+                : new UnsupportedGameInjector();
         }
 
-        // Injection only works on Windows (it uses the Win32 API).
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            return new WindowsGameInjector();
-        }
-
-        return new UnsupportedGameInjector();
+        // Every other method has the game load the patcher on its own, so starting it is all that
+        // is left. How that happens depends on the host, not on the method.
+        return DeploymentPolicy.CanStartGameDirectly()
+            ? new DirectGameLauncher()
+            : new ConfiguredGameLauncher(launchConfig ?? new LaunchConfig());
     }
 
     /// <summary>
@@ -122,13 +121,11 @@ public static class GameLauncher
     /// <param name="gameExePath">Path to game executable</param>
     /// <param name="commandLineArgs">Optional command line arguments</param>
     /// <param name="launchConfig">How to start the game, when the host cannot run it directly</param>
-    /// <param name="deployment">The game's deployment method; defaults to the host's</param>
     /// <returns>Launch result with process information</returns>
     public static LaunchResult LaunchVanilla(
         string gameExePath,
         string? commandLineArgs = null,
-        LaunchConfig? launchConfig = null,
-        DeploymentMethod? deployment = null)
+        LaunchConfig? launchConfig = null)
     {
         // Validate game path
         if (string.IsNullOrWhiteSpace(gameExePath) || !File.Exists(gameExePath))
@@ -138,39 +135,8 @@ public static class GameLauncher
 
         // Whether the game is patched changes what gets loaded into it, not how it is
         // started, so an unpatched launch asks the same question a patched one does.
-        if (!DeploymentPolicy.HostStartsGameDirectly(deployment ?? DeploymentPolicy.ForCurrentPlatform()))
-        {
-            return LaunchDispatcher.Start(
-                launchConfig ?? new LaunchConfig(), gameExePath, "No patches are installed.");
-        }
-
-        try
-        {
-            var gameDir = Path.GetDirectoryName(gameExePath);
-
-            var startInfo = new ProcessStartInfo
-            {
-                FileName = gameExePath,
-                Arguments = commandLineArgs ?? string.Empty,
-                UseShellExecute = true,
-                WorkingDirectory = gameDir
-            };
-
-            var process = Process.Start(startInfo);
-
-            if (process == null)
-            {
-                return LaunchResult.Fail("Process.Start returned null - game may have failed to launch");
-            }
-
-            return LaunchResult.Ok(
-                process,
-                injectionPerformed: false,
-                $"Launched {Path.GetFileName(gameExePath)} in vanilla mode (no patches)");
-        }
-        catch (Exception ex)
-        {
-            return LaunchResult.Fail($"Vanilla launch failed: {ex.Message}");
-        }
+        return DeploymentPolicy.CanStartGameDirectly()
+            ? LaunchDispatcher.StartDirectly(gameExePath, commandLineArgs, "No patches are installed.")
+            : LaunchDispatcher.Start(launchConfig ?? new LaunchConfig(), gameExePath, "No patches are installed.");
     }
 }

--- a/src/KPatchCore/Launcher/LaunchDispatcher.cs
+++ b/src/KPatchCore/Launcher/LaunchDispatcher.cs
@@ -92,4 +92,36 @@ internal static class LaunchDispatcher
             return LaunchResult.Fail($"Custom launch failed: {ex.Message}");
         }
     }
+
+    /// <summary>
+    /// Starts the game executable itself, for hosts that can run it. KOTOR resolves chitin.key
+    /// and the override directory relative to the working directory, so it starts in the game
+    /// folder. Returns why it could not rather than throwing.
+    /// </summary>
+    public static LaunchResult StartDirectly(string gameExePath, string? commandLineArgs, string context)
+    {
+        try
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = gameExePath,
+                Arguments = commandLineArgs ?? string.Empty,
+                UseShellExecute = true,
+                WorkingDirectory = Path.GetDirectoryName(gameExePath),
+            };
+
+            var process = Process.Start(startInfo);
+            if (process == null)
+            {
+                return LaunchResult.Fail("Process.Start returned null - game may have failed to launch");
+            }
+
+            return LaunchResult.Ok(process, injectionPerformed: false,
+                $"Launched {Path.GetFileName(gameExePath)}. {context}");
+        }
+        catch (Exception ex)
+        {
+            return LaunchResult.Fail($"Launch failed: {ex.Message}");
+        }
+    }
 }

--- a/src/KPatchCore/Launcher/LaunchDispatcher.cs
+++ b/src/KPatchCore/Launcher/LaunchDispatcher.cs
@@ -98,7 +98,16 @@ internal static class LaunchDispatcher
     /// and the override directory relative to the working directory, so it starts in the game
     /// folder. Returns why it could not rather than throwing.
     /// </summary>
-    public static LaunchResult StartDirectly(string gameExePath, string? commandLineArgs, string context)
+    /// <param name="patched">
+    /// Whether the game has patches installed. Nothing is injected either way here, so this cannot
+    /// be inferred from the launch itself: with the library proxy the game loads the patcher on its
+    /// own and the launch looks exactly like an unpatched one.
+    /// </param>
+    public static LaunchResult StartDirectly(
+        string gameExePath,
+        string? commandLineArgs,
+        string context,
+        bool patched)
     {
         try
         {
@@ -116,8 +125,10 @@ internal static class LaunchDispatcher
                 return LaunchResult.Fail("Process.Start returned null - game may have failed to launch");
             }
 
-            return LaunchResult.Ok(process, injectionPerformed: false,
-                $"Launched {Path.GetFileName(gameExePath)}. {context}");
+            var message = $"Launched {Path.GetFileName(gameExePath)}. {context}";
+            return patched
+                ? LaunchResult.Patched(process, injectionPerformed: false, message)
+                : LaunchResult.Vanilla(process, message);
         }
         catch (Exception ex)
         {

--- a/src/KPatchCore/Launcher/LaunchResult.cs
+++ b/src/KPatchCore/Launcher/LaunchResult.cs
@@ -43,20 +43,42 @@ public sealed class LaunchResult
     public List<string> Messages { get; init; } = new();
 
     /// <summary>
-    /// Creates a successful launch result
+    /// Creates a result for a launch that got the patches into the game.
     /// </summary>
     /// <param name="process">The launched process</param>
-    /// <param name="injectionPerformed">Whether DLL injection was performed</param>
+    /// <param name="injectionPerformed">Whether the patcher was injected, as opposed to the game
+    /// loading it itself</param>
     /// <param name="message">Optional message</param>
-    /// <returns>Successful launch result</returns>
-    public static LaunchResult Ok(Process process, bool injectionPerformed, string? message = null)
+    public static LaunchResult Patched(Process process, bool injectionPerformed, string? message = null)
+    {
+        return Create(process, injectionPerformed, vanillaLaunch: false, message);
+    }
+
+    /// <summary>
+    /// Creates a result for a launch of a game with no patches installed.
+    /// </summary>
+    /// <param name="process">The launched process</param>
+    /// <param name="message">Optional message</param>
+    public static LaunchResult Vanilla(Process process, string? message = null)
+    {
+        return Create(process, injectionPerformed: false, vanillaLaunch: true, message);
+    }
+
+    // Whether the patcher was injected and whether the game is patched are separate facts. They
+    // agreed only while injection was the one way patches reached a Windows game; the library
+    // proxy has the game load the patcher itself, so a patched launch injects nothing.
+    private static LaunchResult Create(
+        Process process,
+        bool injectionPerformed,
+        bool vanillaLaunch,
+        string? message)
     {
         var result = new LaunchResult
         {
             Success = true,
             GameProcess = process,
             InjectionPerformed = injectionPerformed,
-            VanillaLaunch = !injectionPerformed
+            VanillaLaunch = vanillaLaunch
         };
 
         if (message != null)

--- a/src/KPatchCore/Launcher/ProcessInjector.cs
+++ b/src/KPatchCore/Launcher/ProcessInjector.cs
@@ -133,7 +133,7 @@ internal static class ProcessInjector
 
                 var process = Process.GetProcessById(pi.dwProcessId);
 
-                return LaunchResult.Ok(
+                return LaunchResult.Patched(
                     process,
                     injectionPerformed: true,
                     $"Successfully launched {Path.GetFileName(gameExePath)} with DLL injection");
@@ -364,7 +364,7 @@ internal static class ProcessInjector
 
             Console.WriteLine("[KPatchCore] DLL injected successfully into Steam game");
 
-            return LaunchResult.Ok(
+            return LaunchResult.Patched(
                 gameProcess,
                 injectionPerformed: true,
                 $"Successfully launched {Path.GetFileName(gameExePath)} with delayed injection (Steam)");

--- a/src/KPatchCore/Managers/InstallStateManager.cs
+++ b/src/KPatchCore/Managers/InstallStateManager.cs
@@ -34,8 +34,8 @@ public static class InstallStateManager
         string gameExePath,
         GameVersion originalVersion,
         IEnumerable<string> installedPatches,
-        bool kproxyInstalled = false,
-        bool elfNeededInstalled = false)
+        bool libraryProxyInstalled = false,
+        bool linkedDependencyInstalled = false)
     {
         if (string.IsNullOrWhiteSpace(gameExePath) || !File.Exists(gameExePath))
         {
@@ -85,8 +85,8 @@ public static class InstallStateManager
                     .Where(id => !string.IsNullOrWhiteSpace(id))
                     .Distinct(StringComparer.OrdinalIgnoreCase)
                     .ToList(),
-                KProxyInstalled = kproxyInstalled,
-                ElfNeededInstalled = elfNeededInstalled,
+                LibraryProxyInstalled = libraryProxyInstalled,
+                LinkedDependencyInstalled = linkedDependencyInstalled,
                 CreatedAt = existing?.CreatedAt ?? DateTime.Now,
                 UpdatedAt = DateTime.Now
             };

--- a/src/KPatchCore/Managers/PatchOrchestrator.cs
+++ b/src/KPatchCore/Managers/PatchOrchestrator.cs
@@ -40,23 +40,20 @@ public class PatchOrchestrator
     /// <param name="gameExePath">Path to the game executable</param>
     /// <param name="patchIds">Patch IDs to install</param>
     /// <param name="createBackup">Whether to create a backup before installation</param>
-    /// <param name="patcherDllPath">Path to KotorPatcher.dll (optional)</param>
-    /// <param name="patcherSoPath">Path to KotorPatcher.so for the native Linux ELF (optional)</param>
+    /// <param name="patcherDirectory">Directory the patcher modules and proxy library ship in (optional)</param>
     /// <returns>Installation result</returns>
     public PatchApplicator.InstallResult InstallPatches(
         string gameExePath,
         IEnumerable<string> patchIds,
         bool createBackup = true,
-        string? patcherDllPath = null,
-        string? patcherSoPath = null)
+        string? patcherDirectory = null)
     {
         var options = new PatchApplicator.InstallOptions
         {
             GameExePath = gameExePath,
             PatchIds = patchIds.ToList(),
             CreateBackup = createBackup,
-            PatcherDllPath = patcherDllPath,
-            PatcherSoPath = patcherSoPath
+            PatcherDirectory = patcherDirectory
         };
 
         return _applicator.InstallPatches(options);

--- a/src/KPatchCore/Models/ManagedInstallState.cs
+++ b/src/KPatchCore/Models/ManagedInstallState.cs
@@ -54,12 +54,12 @@ public sealed class ManagedInstallState
     /// Whether the KProxy was staged (the game's binkw32.dll renamed to
     /// binkw32Hooked.dll and the proxy put in its place).
     /// </summary>
-    public bool KProxyInstalled { get; init; }
+    public bool LibraryProxyInstalled { get; init; }
 
     /// <summary>
-    /// Whether KotorPatcher.so was added to the native Linux game ELF's DT_NEEDED list.
+    /// Whether the patcher was added to the game executable's own dependency list.
     /// </summary>
-    public bool ElfNeededInstalled { get; init; }
+    public bool LinkedDependencyInstalled { get; init; }
 
     /// <summary>
     /// When KPM first claimed this install.

--- a/src/KPatchCore/Parsers/ElfExecutableImage.cs
+++ b/src/KPatchCore/Parsers/ElfExecutableImage.cs
@@ -5,7 +5,7 @@ namespace KPatchCore.Parsers;
 
 /// <summary>
 /// <see cref="IExecutableImage"/> over an ELF executable. Address mapping uses LibObjectFile (the same
-/// dependency ElfInjector uses) to walk the PT_LOAD segments: a virtual address maps to a file offset via
+/// dependency ElfDependencies uses) to walk the PT_LOAD segments: a virtual address maps to a file offset via
 /// offset = segment.Position + (va - segment.VirtualAddress) for the segment whose file-backed range
 /// covers it. The byte read/write itself is a direct, size-preserving file edit, so it never triggers a
 /// layout rewrite of the executable.

--- a/src/KPatchCore/Parsers/ExecutableFormat.cs
+++ b/src/KPatchCore/Parsers/ExecutableFormat.cs
@@ -1,0 +1,66 @@
+using KPatchCore.Models;
+
+namespace KPatchCore.Parsers;
+
+/// <summary>The on-disk container an executable uses.</summary>
+internal enum ExecutableFormat
+{
+    /// <summary>Windows Portable Executable.</summary>
+    Pe,
+
+    /// <summary>Linux ELF.</summary>
+    Elf,
+
+    /// <summary>macOS Mach-O, thin or universal.</summary>
+    MachO,
+}
+
+/// <summary>
+/// Identifies an executable's container from its first four bytes. Both the byte-patching and the
+/// dependency-editing sides need this, and neither should carry its own copy of the magic numbers.
+/// </summary>
+internal static class ExecutableFormatDetector
+{
+    public static PatchResult<ExecutableFormat> Detect(string exePath)
+    {
+        if (!File.Exists(exePath))
+            return PatchResult<ExecutableFormat>.Fail($"Executable not found: {exePath}");
+
+        var magic = new byte[4];
+        try
+        {
+            using var stream = File.OpenRead(exePath);
+            if (stream.Read(magic, 0, magic.Length) < magic.Length)
+                return PatchResult<ExecutableFormat>.Fail(
+                    $"{Path.GetFileName(exePath)} is too small to be an executable.");
+        }
+        catch (Exception ex)
+        {
+            return PatchResult<ExecutableFormat>.Fail(
+                $"Failed to read {Path.GetFileName(exePath)}: {ex.Message}");
+        }
+
+        // ELF starts with 0x7F 'E' 'L' 'F'; a PE starts with the DOS stub's 'M' 'Z'.
+        if (magic[0] == 0x7F && magic[1] == (byte)'E' && magic[2] == (byte)'L' && magic[3] == (byte)'F')
+            return PatchResult<ExecutableFormat>.Ok(ExecutableFormat.Elf);
+        if (magic[0] == (byte)'M' && magic[1] == (byte)'Z')
+            return PatchResult<ExecutableFormat>.Ok(ExecutableFormat.Pe);
+        if (IsMachOMagic(magic))
+            return PatchResult<ExecutableFormat>.Ok(ExecutableFormat.MachO);
+
+        return PatchResult<ExecutableFormat>.Fail(
+            $"{Path.GetFileName(exePath)} is not a PE, ELF or Mach-O executable.");
+    }
+
+    // Mach-O comes in four flavours here: a thin image in either byte order (0xFEEDFACE 32-bit,
+    // 0xFEEDFACF 64-bit) and a universal binary (0xCAFEBABE, or 0xCAFEBABF for 64-bit offsets).
+    // The fat header is always big-endian, whatever the images inside it are.
+    private static bool IsMachOMagic(byte[] magic)
+    {
+        uint le = (uint)(magic[0] | magic[1] << 8 | magic[2] << 16 | magic[3] << 24);
+        uint be = (uint)(magic[3] | magic[2] << 8 | magic[1] << 16 | magic[0] << 24);
+        return le is 0xFEEDFACE or 0xFEEDFACF
+            || be is 0xFEEDFACE or 0xFEEDFACF
+            || be is 0xCAFEBABE or 0xCAFEBABF;
+    }
+}

--- a/src/KPatchCore/Parsers/ExecutableImage.cs
+++ b/src/KPatchCore/Parsers/ExecutableImage.cs
@@ -17,34 +17,22 @@ internal interface IExecutableImage
 
 /// <summary>
 /// Opens an executable as the right <see cref="IExecutableImage"/> for its format. This is the single
-/// place the PE-vs-ELF decision is made, so callers (the STATIC hook applicator) stay format-agnostic.
+/// place that decision is made, so callers (the STATIC hook applicator) stay format-agnostic.
 /// </summary>
 internal static class ExecutableImage
 {
     public static PatchResult<IExecutableImage> Open(string exePath)
     {
-        if (!File.Exists(exePath))
-            return PatchResult<IExecutableImage>.Fail($"Executable not found: {exePath}");
+        var format = ExecutableFormatDetector.Detect(exePath);
+        if (!format.Success)
+            return PatchResult<IExecutableImage>.Fail(format.Error!);
 
-        var magic = new byte[4];
-        try
+        return format.Data switch
         {
-            using var stream = File.OpenRead(exePath);
-            if (stream.Read(magic, 0, magic.Length) < magic.Length)
-                return PatchResult<IExecutableImage>.Fail($"{Path.GetFileName(exePath)} is too small to be an executable.");
-        }
-        catch (Exception ex)
-        {
-            return PatchResult<IExecutableImage>.Fail($"Failed to read {Path.GetFileName(exePath)}: {ex.Message}");
-        }
-
-        // ELF starts with 0x7F 'E' 'L' 'F'; a PE (DOS stub) starts with 'M' 'Z'.
-        if (magic[0] == 0x7F && magic[1] == (byte)'E' && magic[2] == (byte)'L' && magic[3] == (byte)'F')
-            return ElfExecutableImage.Open(exePath);
-        if (magic[0] == (byte)'M' && magic[1] == (byte)'Z')
-            return PeExecutableImage.Open(exePath);
-
-        return PatchResult<IExecutableImage>.Fail(
-            $"{Path.GetFileName(exePath)} is neither a PE nor an ELF executable.");
+            ExecutableFormat.Elf => ElfExecutableImage.Open(exePath),
+            ExecutableFormat.Pe => PeExecutableImage.Open(exePath),
+            _ => PatchResult<IExecutableImage>.Fail(
+                $"{Path.GetFileName(exePath)} is a {format.Data} executable, which byte patching does not support yet."),
+        };
     }
 }

--- a/src/KPatchLauncher/Models/AppSettings.cs
+++ b/src/KPatchLauncher/Models/AppSettings.cs
@@ -34,6 +34,12 @@ public class AppSettings
     public List<string> CheckedPatchIds { get; set; } = new();
 
     /// <summary>
+    /// Whether to deploy through the library proxy where injection would otherwise be used.
+    /// Only meaningful on Windows; Linux uses the proxy regardless.
+    /// </summary>
+    public bool PreferLibraryProxy { get; set; }
+
+    /// <summary>
     /// How to start the game when patches are deployed via proxy (Steam or a
     /// custom command). Unused by the injection method.
     /// </summary>

--- a/src/KPatchLauncher/Program.cs
+++ b/src/KPatchLauncher/Program.cs
@@ -34,9 +34,71 @@ class Program
             // a game whose proxy already loads the patcher.
             DeploymentPolicy.PreferLibraryProxy = AppSettings.Load().PreferLibraryProxy;
 
+            if (!TryTakeDeploymentOption(ref args, out var deploymentError))
+            {
+                Console.WriteLine($"ERROR: {deploymentError}");
+                return 1;
+            }
+
             // CLI mode - launch game with patches
             return RunCli(args);
         }
+    }
+
+    /// <summary>
+    /// Consumes "--deployment proxy|injection" from <paramref name="args"/> and applies it for
+    /// this run, leaving what remains positional for the callers that index into it.
+    /// </summary>
+    /// <remarks>
+    /// The choice is not written back to the settings file. A scripted install should not decide
+    /// what the window does the next time somebody opens it.
+    /// </remarks>
+    /// <returns>False when the option is present but unusable, with the reason in
+    /// <paramref name="error"/>.</returns>
+    private static bool TryTakeDeploymentOption(ref string[] args, out string? error)
+    {
+        error = null;
+
+        var index = Array.FindIndex(args, a => a.Equals("--deployment", StringComparison.OrdinalIgnoreCase));
+        if (index < 0)
+        {
+            return true;
+        }
+
+        if (index + 1 >= args.Length)
+        {
+            error = "--deployment needs a value: proxy or injection.";
+            return false;
+        }
+
+        var value = args[index + 1];
+        DeploymentMethod requested;
+        if (value.Equals("proxy", StringComparison.OrdinalIgnoreCase))
+        {
+            DeploymentPolicy.PreferLibraryProxy = true;
+            requested = DeploymentMethod.LibraryProxy;
+        }
+        else if (value.Equals("injection", StringComparison.OrdinalIgnoreCase))
+        {
+            DeploymentPolicy.PreferLibraryProxy = false;
+            requested = DeploymentMethod.RuntimeInjection;
+        }
+        else
+        {
+            error = $"Unknown deployment \"{value}\". Use proxy or injection.";
+            return false;
+        }
+
+        // Asking for something the host cannot do is not fatal, but it would otherwise be silent:
+        // a Linux host has no way to inject and stays on the proxy whatever was asked for.
+        var effective = DeploymentPolicy.ForCurrentPlatform();
+        if (effective != requested)
+        {
+            Console.WriteLine($"Note: this host cannot use {value}; deploying via {effective} instead.");
+        }
+
+        args = args.Where((_, i) => i != index && i != index + 1).ToArray();
+        return true;
     }
 
     /// <summary>
@@ -71,6 +133,7 @@ class Program
         if (args.Length < 3)
         {
             Console.WriteLine("Usage: KPatchLauncher.exe <game_executable.exe> --patches <patches_directory> [patch_id]...");
+            Console.WriteLine("       [--deployment proxy|injection]  how the patcher gets into the game");
             return 1;
         }
 
@@ -139,7 +202,7 @@ class Program
                 Console.WriteLine("ERROR: Could not find game executable.");
                 Console.WriteLine();
                 Console.WriteLine("Usage:");
-                Console.WriteLine("  KPatchLauncher.exe [game_executable.exe]");
+                Console.WriteLine("  KPatchLauncher.exe [game_executable.exe] [--deployment proxy|injection]");
                 Console.WriteLine();
                 Console.WriteLine("Place this launcher in the same directory as the game executable,");
                 Console.WriteLine("or specify the game executable path as an argument.");

--- a/src/KPatchLauncher/Program.cs
+++ b/src/KPatchLauncher/Program.cs
@@ -92,11 +92,10 @@ class Program
             return 1;
         }
 
-        var patcherDllPath = Path.Combine(AppContext.BaseDirectory, PatcherDllName);
         var result = orchestrator.InstallPatches(
             gameExePath,
             patchIds,
-            patcherDllPath: File.Exists(patcherDllPath) ? patcherDllPath : null);
+            patcherDirectory: AppContext.BaseDirectory);
         if (!result.Success)
         {
             Console.WriteLine($"ERROR: {result.Error}");

--- a/src/KPatchLauncher/Program.cs
+++ b/src/KPatchLauncher/Program.cs
@@ -5,6 +5,7 @@ using KPatchCore.Detectors;
 using KPatchCore.Launcher;
 using KPatchCore.Managers;
 using KPatchCore.Models;
+using KPatchLauncher.Models;
 
 namespace KPatchLauncher;
 
@@ -27,6 +28,12 @@ class Program
         }
         else
         {
+            // The deployment preference is machine configuration, and the CLI installs into and
+            // launches the same game the window does. Without reading it here a CLI install would
+            // quietly put a proxy deployment back on injection, and a CLI launch would inject into
+            // a game whose proxy already loads the patcher.
+            DeploymentPolicy.PreferLibraryProxy = AppSettings.Load().PreferLibraryProxy;
+
             // CLI mode - launch game with patches
             return RunCli(args);
         }

--- a/src/KPatchLauncher/ViewModels/MainViewModel.cs
+++ b/src/KPatchLauncher/ViewModels/MainViewModel.cs
@@ -815,24 +815,16 @@ public class MainViewModel : ViewModelBase
             // during the reinstall that follows.
             await Task.Run(() => PatchRemover.RemoveAllPatches(GamePath, removeManagedState: false));
 
-            // Get patcher DLL path (should be in same directory as launcher)
-            // AppContext.BaseDirectory works reliably with both regular and single-file builds
-            var appDir = AppContext.BaseDirectory;
-            var patcherDllPath = Path.Combine(appDir, "KotorPatcher.dll");
-            // The native Linux engine, staged when patching the native ELF.
-            var patcherSoPath = Path.Combine(appDir, "KotorPatcher.so");
-            // The KProxy ships alongside the launcher; staged when deploying via proxy.
-            var proxyDllPath = Path.Combine(appDir, "binkw32.dll");
-
+            // The patcher modules and the KProxy all ship next to the launcher. Which one gets
+            // staged is the deployment method's call, so only the directory is passed.
+            // AppContext.BaseDirectory works reliably with both regular and single-file builds.
             var applicator = new PatchApplicator(_repository);
             var options = new PatchApplicator.InstallOptions
             {
                 GameExePath = GamePath,
                 PatchIds = checkedPatches.Select(p => p.Id).ToList(),
                 CreateBackup = true,
-                PatcherDllPath = File.Exists(patcherDllPath) ? patcherDllPath : null,
-                PatcherSoPath = File.Exists(patcherSoPath) ? patcherSoPath : null,
-                ProxyDllPath = File.Exists(proxyDllPath) ? proxyDllPath : null
+                PatcherDirectory = AppContext.BaseDirectory
             };
 
             // Run on background thread

--- a/src/KPatchLauncher/ViewModels/MainViewModel.cs
+++ b/src/KPatchLauncher/ViewModels/MainViewModel.cs
@@ -194,13 +194,12 @@ public class MainViewModel : ViewModelBase
     }
 
     /// <summary>
-    /// Whether the launch-method controls apply. They are read wherever the manager
-    /// cannot start the game itself and the user's choice of Steam or a custom command
-    /// is what actually starts it. Injection runs the executable directly and ignores
-    /// them, so they stay hidden there.
+    /// Whether the launch-method controls apply. They matter only where the manager cannot start
+    /// the game itself and the user's choice of Steam or a custom command is what starts it.
+    /// Windows runs the executable directly whichever deployment method is in use, so they stay
+    /// hidden there rather than appearing when the proxy is switched on.
     /// </summary>
-    public bool ShowLaunchSettings =>
-        !DeploymentPolicy.HostStartsGameDirectly(DeploymentPolicy.ForCurrentPlatform());
+    public bool ShowLaunchSettings => !DeploymentPolicy.CanStartGameDirectly();
 
     /// <summary>
     /// When true, the game is launched with <see cref="CustomLaunchCommand"/>

--- a/src/KPatchLauncher/ViewModels/MainViewModel.cs
+++ b/src/KPatchLauncher/ViewModels/MainViewModel.cs
@@ -923,15 +923,16 @@ public class MainViewModel : ViewModelBase
 
             await Dispatcher.UIThread.InvokeAsync(() =>
             {
-                if (result.Success && result.ProcessId.HasValue)
+                if (result.Success)
                 {
-                    var mode = result.VanillaLaunch ? "no patches" : "with patches";
-                    SetOperationInProgress(false, $"Game launched {mode} (PID: {result.ProcessId})");
-                }
-                else if (result.Success)
-                {
-                    // Process-less launch (e.g. through Steam); show its message.
-                    SetOperationInProgress(false, result.Messages.FirstOrDefault() ?? "Game launched");
+                    // The launcher's own message says how the game was started and how the
+                    // patches got in, which differs per deployment method. A launch the manager
+                    // started itself also has a pid; one handed to Steam or a custom command does
+                    // not, since the manager never owns that process.
+                    var detail = result.Messages.FirstOrDefault()
+                        ?? (result.VanillaLaunch ? "Game launched, no patches" : "Game launched with patches");
+                    var pid = result.ProcessId.HasValue ? $" (PID: {result.ProcessId})" : string.Empty;
+                    SetOperationInProgress(false, detail + pid);
                 }
                 else
                 {

--- a/src/KPatchLauncher/ViewModels/MainViewModel.cs
+++ b/src/KPatchLauncher/ViewModels/MainViewModel.cs
@@ -60,6 +60,7 @@ public class MainViewModel : ViewModelBase
         _patchesPath = _settings.PatchesPath;
         _useCustomLaunch = _settings.LaunchMethod == LaunchMethod.Custom;
         _customLaunchCommand = _settings.CustomLaunchCommand;
+        DeploymentPolicy.PreferLibraryProxy = _settings.PreferLibraryProxy;
         ClearPersistedPatchSelection();
 
         // Create simple commands
@@ -123,6 +124,7 @@ public class MainViewModel : ViewModelBase
         {
             if (SetProperty(ref _hasInstalledPatches, value))
             {
+                OnPropertyChanged(nameof(CanChangeDeployment));
                 ((SimpleCommand)UninstallAllCommand).RaiseCanExecuteChanged();
             }
         }
@@ -200,6 +202,41 @@ public class MainViewModel : ViewModelBase
     /// hidden there rather than appearing when the proxy is switched on.
     /// </summary>
     public bool ShowLaunchSettings => !DeploymentPolicy.CanStartGameDirectly();
+
+    /// <summary>
+    /// Whether the game is reached through the library proxy instead of injection. Only Windows
+    /// can choose; Linux is on the proxy either way, which is why the menu item is disabled there.
+    /// </summary>
+    public bool PreferLibraryProxy
+    {
+        get => DeploymentPolicy.PreferLibraryProxy;
+        set
+        {
+            if (DeploymentPolicy.PreferLibraryProxy == value)
+            {
+                return;
+            }
+
+            DeploymentPolicy.PreferLibraryProxy = value;
+            _settings.PreferLibraryProxy = value;
+            _settings.Save();
+            OnPropertyChanged();
+        }
+    }
+
+    /// <summary>
+    /// Whether to offer the deployment choice at all. Hidden where there is nothing to choose:
+    /// a host that cannot inject, or a game whose format settles the method itself.
+    /// </summary>
+    public bool ShowDeploymentOption => DeploymentPolicy.HasDeploymentChoice(_detectedGameVersion);
+
+    /// <summary>
+    /// Whether the deployment method can be changed right now. Switching it with patches installed
+    /// would leave the game staged for the previous method, so it is fixed until they come out.
+    /// This is a temporary state, unlike <see cref="ShowDeploymentOption"/>, so the control stays
+    /// visible and goes disabled.
+    /// </summary>
+    public bool CanChangeDeployment => !HasInstalledPatches;
 
     /// <summary>
     /// When true, the game is launched with <see cref="CustomLaunchCommand"/>
@@ -570,6 +607,7 @@ public class MainViewModel : ViewModelBase
         ClearAllPatchSelections(clearInstalledState: true, removeOrphanedPatches: true);
         _detectedGameVersion = null;
         KotorVersion = "Unknown";
+        OnPropertyChanged(nameof(ShowDeploymentOption));
         UpdatePatchCompatibility();
     }
 
@@ -1135,6 +1173,7 @@ public class MainViewModel : ViewModelBase
             var v = versionInfo.Data;
             _detectedGameVersion = v;
             KotorVersion = v.DisplayName;
+            OnPropertyChanged(nameof(ShowDeploymentOption));
 
             // Switch theme based on detected game title
             if (Application.Current is App app)
@@ -1152,6 +1191,7 @@ public class MainViewModel : ViewModelBase
     {
         _detectedGameVersion = null;
         KotorVersion = "Unknown";
+        OnPropertyChanged(nameof(ShowDeploymentOption));
 
         // Load default theme (KOTOR 1) for unknown games
         if (Application.Current is App app)

--- a/src/KPatchLauncher/Views/MainWindow.axaml
+++ b/src/KPatchLauncher/Views/MainWindow.axaml
@@ -114,263 +114,306 @@
         <Style Selector="ScrollViewer">
             <Setter Property="Background" Value="{DynamicResource BackgroundBrush}"/>
         </Style>
+
+        <Style Selector="Menu">
+            <Setter Property="Background" Value="{DynamicResource BackgroundBrush}"/>
+            <Setter Property="Foreground" Value="{DynamicResource PrimaryBrush}"/>
+        </Style>
+        <Style Selector="MenuItem">
+            <Setter Property="Background" Value="{DynamicResource BackgroundBrush}"/>
+            <Setter Property="Foreground" Value="{DynamicResource PrimaryBrush}"/>
+        </Style>
+        <Style Selector="MenuItem /template/ Border#PART_LayoutRoot">
+            <Setter Property="Background" Value="{DynamicResource BackgroundBrush}"/>
+        </Style>
+        <Style Selector="MenuItem:pointerover /template/ Border#PART_LayoutRoot">
+            <Setter Property="Background" Value="{DynamicResource SelectionBackgroundDarkBrush}"/>
+        </Style>
+        <Style Selector="MenuItem:selected /template/ Border#PART_LayoutRoot">
+            <Setter Property="Background" Value="{DynamicResource SelectionBackgroundBrush}"/>
+        </Style>
+        <Style Selector="MenuItem:pointerover">
+            <Setter Property="Foreground" Value="{DynamicResource AccentBrush}"/>
+        </Style>
+        <Style Selector="MenuItem:disabled">
+            <Setter Property="Opacity" Value="0.4"/>
+        </Style>
+        <Style Selector="Separator">
+            <Setter Property="Background" Value="{DynamicResource PrimaryBrush}"/>
+        </Style>
     </Window.Styles>
 
-    <Grid RowDefinitions="Auto,Auto,*,Auto,Auto,Auto,Auto" Margin="10">
+    <DockPanel>
 
-        <!-- Game Path -->
-        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,10">
-            <TextBlock Text="Game:" VerticalAlignment="Center" Width="60"/>
-            <TextBox Text="{Binding GamePath}"
-                     Width="600"
-                     Watermark="Path to swkotor.exe"
-                     Margin="10,0"/>
-            <Button Content="Browse"
-                    Command="{Binding BrowseGameCommand}"
-                    Width="100"
-                    Margin="5,0"/>
-            <Button Content="Refresh"
-                    Command="{Binding RefreshCommand}"
-                    Width="100"/>
-        </StackPanel>
+        <!-- Drawn in-window, which is right on Windows and Linux. macOS puts menus in the system
+             bar, so a macOS build wants NativeMenu rather than a second copy inside the window. -->
+        <Menu DockPanel.Dock="Top">
+            <MenuItem Header="_File">
+                <MenuItem Header="Select _Game..." Command="{Binding BrowseGameCommand}"/>
+                <MenuItem Header="Select _Patches Folder..." Command="{Binding BrowsePatchesCommand}"/>
+                <Separator/>
+                <MenuItem Header="_Refresh" Command="{Binding RefreshCommand}"/>
+                <Separator/>
+                <MenuItem Header="E_xit" Click="OnExitClicked"/>
+            </MenuItem>
+        </Menu>
 
-        <!-- Patches Directory -->
-        <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,0,0,10">
-            <TextBlock Text="Patches:" VerticalAlignment="Center" Width="60"/>
-            <TextBox Text="{Binding PatchesPath}"
-                     Width="705"
-                     Watermark="Directory containing .kpatch files"
-                     Margin="10,0"/>
-            <Button Content="Browse"
-                    Command="{Binding BrowsePatchesCommand}"
-                    Width="100"
-                    Margin="5,0,0,0"/>
-        </StackPanel>
+        <Grid RowDefinitions="Auto,Auto,*,Auto,Auto,Auto,Auto" Margin="10">
 
-        <!-- Main Content: Patches List + Detail Panel -->
-        <Grid Grid.Row="2" ColumnDefinitions="2*,3*" Margin="0,10">
+            <!-- Game Path -->
+            <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="0,0,0,10">
+                <TextBlock Text="Game:" VerticalAlignment="Center" Width="60"/>
+                <TextBox Text="{Binding GamePath}"
+                         Width="600"
+                         Watermark="Path to swkotor.exe"
+                         Margin="10,0"/>
+                <Button Content="Browse"
+                        Command="{Binding BrowseGameCommand}"
+                        Width="100"
+                        Margin="5,0"/>
+                <Button Content="Refresh"
+                        Command="{Binding RefreshCommand}"
+                        Width="100"/>
+            </StackPanel>
 
-            <!-- Patches List (Left) -->
-            <Border Grid.Column="0" BorderThickness="1" Padding="5" Margin="0,0,5,0">
-                <DockPanel>
-                    <TextBlock DockPanel.Dock="Top"
-                               Text="Patches"
-                               FontWeight="Bold"
-                               FontSize="14"
-                               Margin="0,0,0,8"/>
+            <!-- Patches Directory -->
+            <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,0,0,10">
+                <TextBlock Text="Patches:" VerticalAlignment="Center" Width="60"/>
+                <TextBox Text="{Binding PatchesPath}"
+                         Width="705"
+                         Watermark="Directory containing .kpatch files"
+                         Margin="10,0"/>
+                <Button Content="Browse"
+                        Command="{Binding BrowsePatchesCommand}"
+                        Width="100"
+                        Margin="5,0,0,0"/>
+            </StackPanel>
 
-                    <CheckBox DockPanel.Dock="Top"
-                              IsThreeState="True"
-                              IsChecked="{Binding SelectAllPatches}"
-                              IsEnabled="{Binding HasVisiblePatches}"
-                              Foreground="{DynamicResource PrimaryBrush}"
-                              Margin="0,0,0,8">
-                        <TextBlock Text="Select All"
-                                   Foreground="{DynamicResource PrimaryBrush}"/>
-                    </CheckBox>
+            <!-- Main Content: Patches List + Detail Panel -->
+            <Grid Grid.Row="2" ColumnDefinitions="2*,3*" Margin="0,10">
 
-                    <ListBox ItemsSource="{Binding VisiblePatches}"
-                             SelectedItem="{Binding SelectedPatch}"
-                             ScrollViewer.HorizontalScrollBarVisibility="Disabled">
-                        <ListBox.ItemTemplate>
-                            <DataTemplate>
-                                <Grid ColumnDefinitions="Auto,*,Auto"
-                                      ToolTip.Tip="{Binding CompatibilityStatus}">
-                                    <!-- Checkbox -->
-                                    <CheckBox Grid.Column="0"
-                                              IsChecked="{Binding IsChecked}"
-                                              VerticalAlignment="Center"
-                                              Margin="0,0,8,0"/>
+                <!-- Patches List (Left) -->
+                <Border Grid.Column="0" BorderThickness="1" Padding="5" Margin="0,0,5,0">
+                    <DockPanel>
+                        <TextBlock DockPanel.Dock="Top"
+                                   Text="Patches"
+                                   FontWeight="Bold"
+                                   FontSize="14"
+                                   Margin="0,0,0,8"/>
 
-                                    <!-- Patch Name -->
-                                    <TextBlock Grid.Column="1"
-                                               Text="{Binding DisplayText}"
-                                               VerticalAlignment="Center"
-                                               TextWrapping="NoWrap"
-                                               TextTrimming="CharacterEllipsis"/>
+                        <CheckBox DockPanel.Dock="Top"
+                                  IsThreeState="True"
+                                  IsChecked="{Binding SelectAllPatches}"
+                                  IsEnabled="{Binding HasVisiblePatches}"
+                                  Foreground="{DynamicResource PrimaryBrush}"
+                                  Margin="0,0,0,8">
+                            <TextBlock Text="Select All"
+                                       Foreground="{DynamicResource PrimaryBrush}"/>
+                        </CheckBox>
 
-                                    <!-- Up/Down Buttons -->
-                                    <StackPanel Grid.Column="2"
-                                                Orientation="Horizontal"
-                                                Spacing="2"
-                                                Margin="8,0,0,0">
-                                        <Button Content="↑"
-                                                Command="{Binding $parent[Window].DataContext.MoveUpCommand}"
-                                                Width="24"
-                                                Height="24"
-                                                Padding="0"
-                                                FontSize="12"
-                                                ToolTip.Tip="Move Up"/>
-                                        <Button Content="↓"
-                                                Command="{Binding $parent[Window].DataContext.MoveDownCommand}"
-                                                Width="24"
-                                                Height="24"
-                                                Padding="0"
-                                                FontSize="12"
-                                                ToolTip.Tip="Move Down"/>
-                                    </StackPanel>
-                                </Grid>
-                            </DataTemplate>
-                        </ListBox.ItemTemplate>
-                    </ListBox>
-                </DockPanel>
-            </Border>
+                        <ListBox ItemsSource="{Binding VisiblePatches}"
+                                 SelectedItem="{Binding SelectedPatch}"
+                                 ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+                            <ListBox.ItemTemplate>
+                                <DataTemplate>
+                                    <Grid ColumnDefinitions="Auto,*,Auto"
+                                          ToolTip.Tip="{Binding CompatibilityStatus}">
+                                        <!-- Checkbox -->
+                                        <CheckBox Grid.Column="0"
+                                                  IsChecked="{Binding IsChecked}"
+                                                  VerticalAlignment="Center"
+                                                  Margin="0,0,8,0"/>
 
-            <!-- Patch Details Panel (Right) -->
-            <Border Grid.Column="1" BorderThickness="1" Padding="10" Margin="5,0,0,0">
-                <ScrollViewer VerticalScrollBarVisibility="Auto">
-                    <Grid>
-                        <!-- Patch Details (when selected) -->
-                        <StackPanel Spacing="10" IsVisible="{Binding SelectedPatch, Converter={x:Static ObjectConverters.IsNotNull}}">
-                            <TextBlock Text="Patch Details"
-                                       FontWeight="Bold"
-                                       FontSize="14"
-                                       Margin="0,0,0,5"/>
+                                        <!-- Patch Name -->
+                                        <TextBlock Grid.Column="1"
+                                                   Text="{Binding DisplayText}"
+                                                   VerticalAlignment="Center"
+                                                   TextWrapping="NoWrap"
+                                                   TextTrimming="CharacterEllipsis"/>
 
-                            <!-- Name -->
-                            <StackPanel>
-                                <TextBlock Text="Name:"
-                                           FontWeight="SemiBold"
-                                           Margin="0,0,0,3"/>
-                                <TextBlock Text="{Binding SelectedPatch.Name}"
-                                           TextWrapping="Wrap"/>
-                            </StackPanel>
+                                        <!-- Up/Down Buttons -->
+                                        <StackPanel Grid.Column="2"
+                                                    Orientation="Horizontal"
+                                                    Spacing="2"
+                                                    Margin="8,0,0,0">
+                                            <Button Content="↑"
+                                                    Command="{Binding $parent[Window].DataContext.MoveUpCommand}"
+                                                    Width="24"
+                                                    Height="24"
+                                                    Padding="0"
+                                                    FontSize="12"
+                                                    ToolTip.Tip="Move Up"/>
+                                            <Button Content="↓"
+                                                    Command="{Binding $parent[Window].DataContext.MoveDownCommand}"
+                                                    Width="24"
+                                                    Height="24"
+                                                    Padding="0"
+                                                    FontSize="12"
+                                                    ToolTip.Tip="Move Down"/>
+                                        </StackPanel>
+                                    </Grid>
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
+                    </DockPanel>
+                </Border>
 
-                            <!-- Version -->
-                            <StackPanel>
-                                <TextBlock Text="Version:"
-                                           FontWeight="SemiBold"
-                                           Margin="0,0,0,3"/>
-                                <TextBlock Text="{Binding SelectedPatch.Version}"/>
-                            </StackPanel>
+                <!-- Patch Details Panel (Right) -->
+                <Border Grid.Column="1" BorderThickness="1" Padding="10" Margin="5,0,0,0">
+                    <ScrollViewer VerticalScrollBarVisibility="Auto">
+                        <Grid>
+                            <!-- Patch Details (when selected) -->
+                            <StackPanel Spacing="10" IsVisible="{Binding SelectedPatch, Converter={x:Static ObjectConverters.IsNotNull}}">
+                                <TextBlock Text="Patch Details"
+                                           FontWeight="Bold"
+                                           FontSize="14"
+                                           Margin="0,0,0,5"/>
 
-                            <!-- Author -->
-                            <StackPanel>
-                                <TextBlock Text="Author:"
-                                           FontWeight="SemiBold"
-                                           Margin="0,0,0,3"/>
-                                <TextBlock Text="{Binding SelectedPatch.Author}"/>
-                            </StackPanel>
-
-                            <!-- Description -->
-                            <StackPanel>
-                                <TextBlock Text="Description:"
-                                           FontWeight="SemiBold"
-                                           Margin="0,0,0,3"/>
-                                <TextBlock Text="{Binding SelectedPatch.Description}"
-                                           TextWrapping="Wrap"/>
-                            </StackPanel>
-
-                            <!-- Compatibility Status -->
-                            <StackPanel>
-                                <TextBlock Text="Compatibility:"
-                                           FontWeight="SemiBold"
-                                           Margin="0,0,0,3"/>
-                                <TextBlock Text="{Binding SelectedPatch.CompatibilityStatus}"
-                                           TextWrapping="Wrap"/>
-                            </StackPanel>
-
-                            <!-- Orphaned Warning -->
-                            <Border Background="{DynamicResource ErrorBackgroundBrush}"
-                                    BorderBrush="{DynamicResource ErrorBrush}"
-                                    BorderThickness="1"
-                                    Padding="8"
-                                    IsVisible="{Binding SelectedPatch.IsOrphaned}">
-                                <StackPanel Spacing="5">
-                                    <TextBlock Text="⚠️ Orphaned Patch"
-                                               FontWeight="Bold"
-                                               Foreground="{DynamicResource ErrorBrush}"/>
-                                    <TextBlock Text="This patch is installed in the game but not found in your patches directory. Unchecking it will uninstall it, but it will not appear in the list again."
-                                               TextWrapping="Wrap"
-                                               FontSize="12"/>
+                                <!-- Name -->
+                                <StackPanel>
+                                    <TextBlock Text="Name:"
+                                               FontWeight="SemiBold"
+                                               Margin="0,0,0,3"/>
+                                    <TextBlock Text="{Binding SelectedPatch.Name}"
+                                               TextWrapping="Wrap"/>
                                 </StackPanel>
-                            </Border>
-                        </StackPanel>
 
-                        <!-- No Selection Message -->
-                        <TextBlock Text="Select a patch to view details"
-                                   FontStyle="Italic"
-                                   Opacity="0.6"
-                                   VerticalAlignment="Center"
-                                   HorizontalAlignment="Center"
-                                   IsVisible="{Binding SelectedPatch, Converter={x:Static ObjectConverters.IsNull}}"/>
-                    </Grid>
-                </ScrollViewer>
-            </Border>
-        </Grid>
+                                <!-- Version -->
+                                <StackPanel>
+                                    <TextBlock Text="Version:"
+                                               FontWeight="SemiBold"
+                                               Margin="0,0,0,3"/>
+                                    <TextBlock Text="{Binding SelectedPatch.Version}"/>
+                                </StackPanel>
 
-        <!-- Launch Settings (proxy method only: how the game is started) -->
-        <StackPanel Grid.Row="3"
-                    Orientation="Horizontal"
-                    Spacing="10"
-                    Margin="0,10,0,0"
-                    VerticalAlignment="Center"
-                    IsVisible="{Binding ShowLaunchSettings}">
-            <CheckBox Content="Custom launch command"
-                      IsChecked="{Binding UseCustomLaunch}"
-                      VerticalAlignment="Center"
-                      ToolTip.Tip="Off: launch through Steam. On: run your own command (Lutris, Heroic, Wine...)."/>
-            <TextBox Text="{Binding CustomLaunchCommand}"
-                     Watermark="e.g. wine &quot;{exe}&quot;   ({exe} = game path)"
-                     IsEnabled="{Binding UseCustomLaunch}"
-                     Width="440"
-                     VerticalAlignment="Center"/>
-        </StackPanel>
+                                <!-- Author -->
+                                <StackPanel>
+                                    <TextBlock Text="Author:"
+                                               FontWeight="SemiBold"
+                                               Margin="0,0,0,3"/>
+                                    <TextBlock Text="{Binding SelectedPatch.Author}"/>
+                                </StackPanel>
 
-        <!-- Status Bar -->
-        <Border Grid.Row="4"
-                BorderBrush="{DynamicResource PrimaryBrush}"
-                BorderThickness="0,1,0,0"
-                Padding="5"
-                Margin="0,10,0,5">
-            <Grid ColumnDefinitions="2*,2*,3*">
-                <TextBlock Grid.Column="0"
-                           Text="{Binding StatusMessage}"
-                           FontStyle="Italic"
-                           VerticalAlignment="Center"/>
-                <TextBlock Grid.Column="1"
-                           Text="{Binding PendingChangesMessage}"
-                           FontStyle="Italic"
-                           VerticalAlignment="Center"
-                           HorizontalAlignment="Center"/>
-                <TextBlock Grid.Column="2"
-                           Text="{Binding KotorVersion, StringFormat='Target: {0}'}"
-                           FontStyle="Italic"
-                           VerticalAlignment="Center"
-                           HorizontalAlignment="Right"/>
+                                <!-- Description -->
+                                <StackPanel>
+                                    <TextBlock Text="Description:"
+                                               FontWeight="SemiBold"
+                                               Margin="0,0,0,3"/>
+                                    <TextBlock Text="{Binding SelectedPatch.Description}"
+                                               TextWrapping="Wrap"/>
+                                </StackPanel>
+
+                                <!-- Compatibility Status -->
+                                <StackPanel>
+                                    <TextBlock Text="Compatibility:"
+                                               FontWeight="SemiBold"
+                                               Margin="0,0,0,3"/>
+                                    <TextBlock Text="{Binding SelectedPatch.CompatibilityStatus}"
+                                               TextWrapping="Wrap"/>
+                                </StackPanel>
+
+                                <!-- Orphaned Warning -->
+                                <Border Background="{DynamicResource ErrorBackgroundBrush}"
+                                        BorderBrush="{DynamicResource ErrorBrush}"
+                                        BorderThickness="1"
+                                        Padding="8"
+                                        IsVisible="{Binding SelectedPatch.IsOrphaned}">
+                                    <StackPanel Spacing="5">
+                                        <TextBlock Text="⚠️ Orphaned Patch"
+                                                   FontWeight="Bold"
+                                                   Foreground="{DynamicResource ErrorBrush}"/>
+                                        <TextBlock Text="This patch is installed in the game but not found in your patches directory. Unchecking it will uninstall it, but it will not appear in the list again."
+                                                   TextWrapping="Wrap"
+                                                   FontSize="12"/>
+                                    </StackPanel>
+                                </Border>
+                            </StackPanel>
+
+                            <!-- No Selection Message -->
+                            <TextBlock Text="Select a patch to view details"
+                                       FontStyle="Italic"
+                                       Opacity="0.6"
+                                       VerticalAlignment="Center"
+                                       HorizontalAlignment="Center"
+                                       IsVisible="{Binding SelectedPatch, Converter={x:Static ObjectConverters.IsNull}}"/>
+                        </Grid>
+                    </ScrollViewer>
+                </Border>
             </Grid>
-        </Border>
 
-        <!-- Progress Bar -->
-        <ProgressBar Grid.Row="5"
-                     IsIndeterminate="{Binding IsOperationInProgress}"
-                     Value="{Binding ProgressValue}"
-                     Maximum="100"
-                     Height="8"
-                     Margin="0,5,0,10"
-                     Foreground="{DynamicResource AccentBrush}"
-                     Background="{DynamicResource ProgressBackgroundBrush}"
-                     BorderBrush="{DynamicResource PrimaryBrush}"
-                     BorderThickness="1"/>
+            <!-- Launch Settings (proxy method only: how the game is started) -->
+            <StackPanel Grid.Row="3"
+                        Orientation="Horizontal"
+                        Spacing="10"
+                        Margin="0,10,0,0"
+                        VerticalAlignment="Center"
+                        IsVisible="{Binding ShowLaunchSettings}">
+                <CheckBox Content="Custom launch command"
+                          IsChecked="{Binding UseCustomLaunch}"
+                          VerticalAlignment="Center"
+                          ToolTip.Tip="Off: launch through Steam. On: run your own command (Lutris, Heroic, Wine...)."/>
+                <TextBox Text="{Binding CustomLaunchCommand}"
+                         Watermark="e.g. wine &quot;{exe}&quot;   ({exe} = game path)"
+                         IsEnabled="{Binding UseCustomLaunch}"
+                         Width="440"
+                         VerticalAlignment="Center"/>
+            </StackPanel>
 
-        <!-- Action Buttons -->
-        <StackPanel Grid.Row="6"
-                    Orientation="Horizontal"
-                    HorizontalAlignment="Right"
-                    Spacing="10">
-            <Button Content="Uninstall All"
-                    Command="{Binding UninstallAllCommand}"
-                    Width="120"
-                    Height="35"/>
-            <Button Content="Apply"
-                    Command="{Binding ApplyPatchesCommand}"
-                    Width="120"
-                    Height="35"/>
-            <Button Content="Launch"
-                    Command="{Binding LaunchGameCommand}"
-                    Width="120"
-                    Height="35"/>
-        </StackPanel>
-    </Grid>
+            <!-- Status Bar -->
+            <Border Grid.Row="4"
+                    BorderBrush="{DynamicResource PrimaryBrush}"
+                    BorderThickness="0,1,0,0"
+                    Padding="5"
+                    Margin="0,10,0,5">
+                <Grid ColumnDefinitions="2*,2*,3*">
+                    <TextBlock Grid.Column="0"
+                               Text="{Binding StatusMessage}"
+                               FontStyle="Italic"
+                               VerticalAlignment="Center"/>
+                    <TextBlock Grid.Column="1"
+                               Text="{Binding PendingChangesMessage}"
+                               FontStyle="Italic"
+                               VerticalAlignment="Center"
+                               HorizontalAlignment="Center"/>
+                    <TextBlock Grid.Column="2"
+                               Text="{Binding KotorVersion, StringFormat='Target: {0}'}"
+                               FontStyle="Italic"
+                               VerticalAlignment="Center"
+                               HorizontalAlignment="Right"/>
+                </Grid>
+            </Border>
+
+            <!-- Progress Bar -->
+            <ProgressBar Grid.Row="5"
+                         IsIndeterminate="{Binding IsOperationInProgress}"
+                         Value="{Binding ProgressValue}"
+                         Maximum="100"
+                         Height="8"
+                         Margin="0,5,0,10"
+                         Foreground="{DynamicResource AccentBrush}"
+                         Background="{DynamicResource ProgressBackgroundBrush}"
+                         BorderBrush="{DynamicResource PrimaryBrush}"
+                         BorderThickness="1"/>
+
+            <!-- Action Buttons -->
+            <StackPanel Grid.Row="6"
+                        Orientation="Horizontal"
+                        HorizontalAlignment="Right"
+                        Spacing="10">
+                <Button Content="Uninstall All"
+                        Command="{Binding UninstallAllCommand}"
+                        Width="120"
+                        Height="35"/>
+                <Button Content="Apply"
+                        Command="{Binding ApplyPatchesCommand}"
+                        Width="120"
+                        Height="35"/>
+                <Button Content="Launch"
+                        Command="{Binding LaunchGameCommand}"
+                        Width="120"
+                        Height="35"/>
+            </StackPanel>
+        </Grid>
+    </DockPanel>
 
 </Window>

--- a/src/KPatchLauncher/Views/MainWindow.axaml
+++ b/src/KPatchLauncher/Views/MainWindow.axaml
@@ -156,6 +156,19 @@
                 <Separator/>
                 <MenuItem Header="E_xit" Click="OnExitClicked"/>
             </MenuItem>
+            <!-- The deployment toggle is the only entry, so the menu goes with it. Anything added
+                 here later wants its own visibility rather than the menu's. -->
+            <MenuItem Header="_Options" IsVisible="{Binding ShowDeploymentOption}">
+                <!-- MenuItem.ToggleType arrived after Avalonia 11.0, so the check state lives on a
+                     CheckBox in the header instead. -->
+                <MenuItem ToolTip.Tip="Load the patcher through a stand-in binkw32.dll instead of injecting at launch. Uninstall patches before changing this.">
+                    <MenuItem.Header>
+                        <CheckBox Content="Use library proxy"
+                                  IsChecked="{Binding PreferLibraryProxy}"
+                                  IsEnabled="{Binding CanChangeDeployment}"/>
+                    </MenuItem.Header>
+                </MenuItem>
+            </MenuItem>
         </Menu>
 
         <Grid RowDefinitions="Auto,Auto,*,Auto,Auto,Auto,Auto" Margin="10">

--- a/src/KPatchLauncher/Views/MainWindow.axaml.cs
+++ b/src/KPatchLauncher/Views/MainWindow.axaml.cs
@@ -12,6 +12,10 @@ public partial class MainWindow : Window
         TrySetWindowIcon();
     }
 
+    // Closing the window is the view's business, not the view model's, so this stays in
+    // code-behind rather than becoming a command.
+    private void OnExitClicked(object? sender, Avalonia.Interactivity.RoutedEventArgs e) => Close();
+
     private void TrySetWindowIcon()
     {
         try


### PR DESCRIPTION
This is mainly preparation work :smile: 

macOS support needs a place to plug into, and most of what it needs turned out to be things that were already awkward for Linux. So this reshapes the shared parts first, and along the way makes the Bink proxy available on Windows as a user-facing option.

No behaviour changes for anyone on Windows or Linux unless they go looking for the new toggle. Every commit builds on its own.

### Why the names had to change

`DeploymentMethod.ElfNeeded` named an ELF mechanism. Mach-O does the same thing through a different mechanism, and PE through a third, so the name couldn't be reused without lying about the format. `Proxy` and `Injection` had the opposite problem: they said nothing about who ends up loading the patcher.

The three methods are now named for their effect on the game:

| was | now | what it means |
|---|---|---|
| `Injection` | `RuntimeInjection` | the manager starts the game and writes the patcher into the live process |
| `Proxy` | `LibraryProxy` | a library the game already loads is replaced with ours |
| `ElfNeeded` | `LinkedDependency` | the executable's own dependency list names the patcher |

### The seams macOS will plug into

Adding a dependency to an executable used to be an ELF-only static class called straight from the installer, with nowhere for a second format to attach. It now sits behind a small interface with a factory that identifies the format. There's deliberately no removal operation: uninstall restores the executable from the backup taken before it was touched, which undoes the edit exactly.

Format detection also moved somewhere both the byte-patching side and the dependency side can reach, instead of living inside one of them.

`InstallOptions` carried a separate path for the Windows engine, the native engine, and the proxy, and every caller had to know which mattered. It now takes the directory they all ship in, and the deployment method names the file it wants. Adding a platform stops being a change to the options type and its three callers.


### Using the proxy on Windows

Previously the only way to make Windows use the proxy was to edit `ForCurrentPlatform` and rebuild. That's now
a saved preference with a toggle under a new **Options** menu, next to a standard **File** menu.

The toggle only appears where there's genuinely a choice: it's hidden on a host that can't inject, and hidden for a game whose format settles the question by naming the patcher itself. Where the choice exists but is temporarily unavailable. 

Patches currently installed, since switching would leave the game staged for the old method: the control stays visible and goes disabled. Different reasons, different treatment.

Useful where injection is blocked: an anti-cheat driver, or a preference for  the game being started by something other than the manager.

**Choosing deployment from the command line.** `--deployment proxy|injection` overrides the saved choice for a single run without writing it back, so automation doesn't have to depend on a settings file the GUI wrote. Requests a host can't satisfy report what happened instead of being ignored.
### Some bugs found on the way

Three real ones, all pre-existing except where noted:

**The headless CLI couldn't install on native Linux.** `--install` passed only the Windows engine path, so installing to the native ELF failed on the missing engine and a proxy deployment silently went without its proxy. Fixed by the options change above.

**The command line ignored the deployment preference.** Only the window applied it, so a headless install (which uninstalls before it reinstalls) would quietly move a proxy deployment back to injection, and a headless launch would inject into a game the proxy already serves. Both front ends now read the same saved setting.

**Windows single-file builds could fail to install.** The address databases were located via `Assembly.Location`, which returns an empty string in a single-file build: exactly what Windows ships. The path then resolved against the working directory, so launching from a shortcut pointed elsewhere failed partway through and rolled the install back. Every other lookup in the codebase already used `AppContext.BaseDirectory`; this one now does too.

**Two assumptions that only held while injection was the only way in.** These would have bitten as soon as the toggle was used, so they're fixed ahead of it:

- *Which launcher to use* was decided from the deployment method, but it's a question about the host. Windows can start the game itself whatever loads the patcher: that's what injection has always done. Without this, ticking the proxy sent the launch through Steam, which fails outright on a GOG install, and surfaced launch controls Windows has never needed.

- *What to report afterwards* was inferred from whether injection ran. With the proxy nothing is injected, so a fully patched launch would have said "no patches". Those are now stated rather than inferred. The status line also shows what actually happened instead of the window guessing.

### Publishing

The Windows release has never carried `binkw32.dll`, which didn't matter while the proxy was a Linux-only concern. It's staged now when a build has produced it, and says plainly what won't work when it hasn't.

This will need some work on your side to build the proxy via MSVC. (will need to be added to your VS project)