### PR TITLE
Feat/patcher 64bit wrappers

### DIFF
--- a/src/KotorPatcher/Makefile
+++ b/src/KotorPatcher/Makefile
@@ -65,8 +65,45 @@ BUILD_SO  := $(BUILD)/KotorPatcher.so
 DLL_OUT ?=
 SO_OUT  ?=
 
-.PHONY: all dll so clean
+.PHONY: all dll so test clean
 all: dll so
+
+# Host tests for the code generators. Each assembles a hook site, runs a stub the
+# generator produced, and checks what came back, so they need an x86 host with
+# 32-bit support. The emitted bytes do not depend on the OS, so running them here
+# covers the Windows build too.
+#
+# tests/any_* are built at both widths; tests/t32_* and tests/t64_* pick the
+# wrapper generator that matches their instruction set.
+TEST_ENGINE := src/core/trampoline.cpp src/platform_posix.cpp
+TESTS_ANY   := $(wildcard tests/any_*.cpp)
+TESTS_32    := $(wildcard tests/t32_*.cpp) $(TESTS_ANY)
+TESTS_64    := $(wildcard tests/t64_*.cpp) $(TESTS_ANY)
+TEST_FLAGS  := -std=c++17 -O1 $(INCLUDES) -Itests -Isrc
+
+# The engine logs to stderr as it generates, which drowns the results, so each
+# run is captured and only the non-log lines are shown. The status has to come
+# from the test itself: piping it into a filter would report the filter's.
+test:
+	@mkdir -p $(BUILD)/tests
+	@rc=0; \
+	run() { \
+	  if "$$1" > "$$1.log" 2>&1; then :; else rc=1; fi; \
+	  grep -vE '^\[' "$$1.log" || true; \
+	}; \
+	for t in $(TESTS_32); do \
+	  n=$$(basename $$t .cpp); echo "  [i386]   $$n"; \
+	  $(CXX_LINUX) $(TEST_FLAGS) -m32 -msse2 -o $(BUILD)/tests/$$n-32 $$t \
+	      src/core/wrapper_x86.cpp $(TEST_ENGINE) -ldl || { rc=1; continue; }; \
+	  run $(BUILD)/tests/$$n-32; \
+	done; \
+	for t in $(TESTS_64); do \
+	  n=$$(basename $$t .cpp); echo "  [x86_64] $$n"; \
+	  $(CXX_LINUX) $(TEST_FLAGS) -o $(BUILD)/tests/$$n-64 $$t \
+	      src/core/wrapper_x86_64.cpp $(TEST_ENGINE) -ldl || { rc=1; continue; }; \
+	  run $(BUILD)/tests/$$n-64; \
+	done; \
+	exit $$rc
 
 # The copy is skipped when DLL_OUT/SO_OUT is empty or already points at the built
 # file (-ef: same file), so `make dll DLL_OUT=<build path>` can't cp a file onto itself.

--- a/src/KotorPatcher/include/patcher.h
+++ b/src/KotorPatcher/include/patcher.h
@@ -41,7 +41,7 @@ namespace KotorPatcher {
         // Basic patch information
         std::string dllPath;           // Path to patch DLL (not used for SIMPLE)
         std::string functionName;      // Exported function name in DLL (not used for SIMPLE)
-        uint32_t hookAddress;          // Address in game code to hook
+        uintptr_t hookAddress;         // Address in game code to hook
         std::vector<uint8_t> originalBytes;  // Original bytes (for verification and execution)
                                            // DETOUR: Must be >= 5 bytes, executed in wrapper
                                            // SIMPLE: Any length, verified before replacement
@@ -73,7 +73,7 @@ namespace KotorPatcher {
         // a non-zero int. Lets a hook selectively consume engine events.
         // Caller must include "eax" in excludeFromRestore so the handler's
         // return value survives the wrapper. Default 0 = feature disabled.
-        uint32_t consumedExitAddress = 0;
+        uintptr_t consumedExitAddress = 0;
 
         // Original function pointer (future: for detour trampolines)
         void* originalFunction = nullptr;

--- a/src/KotorPatcher/include/platform.h
+++ b/src/KotorPatcher/include/platform.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <cctype>
 #include <cstddef>
+#include <cstdint>
 #include <string>
 
 // Platform seam for the patcher engine.
@@ -19,16 +20,15 @@ namespace Platform {
     // (OutputDebugStringA); Linux writes it to stderr.
     void Log(const char* message);
 
-    // Allocate `size` bytes of writable memory for a generated stub (a DETOUR
-    // wrapper, a REPLACE code block), or nullptr on failure. The block is not
-    // executable yet: fill it, then seal it with ProtectExec.
-    //
-    // Writable and executable at once is deliberately not offered. macOS refuses
-    // such a mapping, and these games are x86_64-only, so every Apple Silicon Mac
-    // runs them under Rosetta and would hit that refusal.
-    void* AllocExec(std::size_t size);
+    // Allocate `size` bytes of writable memory for generated stubs (DETOUR
+    // wrappers, REPLACE code blocks), or nullptr on failure. Not executable yet:
+    // fill it, then seal it with ProtectExec. `nearAddress` is the game code that
+    // will jump here, and the block is placed within a 5-byte relative jump of it;
+    // pass 0 when nothing will jump here. Placement is best-effort, and
+    // Trampoline::ComputeRel32 decides whether a jump actually reaches.
+    void* AllocExec(std::size_t size, std::uintptr_t nearAddress);
 
-    // Turn a filled AllocExec block into read+execute and make the CPU observe the
+    // Seal a filled AllocExec block as read+execute and let the CPU observe the
     // bytes. Returns false if the protection change failed, in which case nothing
     // may jump to the block.
     bool ProtectExec(void* addr, std::size_t size);

--- a/src/KotorPatcher/include/platform.h
+++ b/src/KotorPatcher/include/platform.h
@@ -19,9 +19,19 @@ namespace Platform {
     // (OutputDebugStringA); Linux writes it to stderr.
     void Log(const char* message);
 
-    // Allocate `size` bytes of read/write/execute memory for generated stubs
-    // (DETOUR wrappers, REPLACE code blocks), or nullptr on failure.
+    // Allocate `size` bytes of writable memory for a generated stub (a DETOUR
+    // wrapper, a REPLACE code block), or nullptr on failure. The block is not
+    // executable yet: fill it, then seal it with ProtectExec.
+    //
+    // Writable and executable at once is deliberately not offered. macOS refuses
+    // such a mapping, and these games are x86_64-only, so every Apple Silicon Mac
+    // runs them under Rosetta and would hit that refusal.
     void* AllocExec(std::size_t size);
+
+    // Turn a filled AllocExec block into read+execute and make the CPU observe the
+    // bytes. Returns false if the protection change failed, in which case nothing
+    // may jump to the block.
+    bool ProtectExec(void* addr, std::size_t size);
 
     // Release memory returned by AllocExec.
     void FreeExec(void* addr, std::size_t size);

--- a/src/KotorPatcher/include/trampoline.h
+++ b/src/KotorPatcher/include/trampoline.h
@@ -23,6 +23,11 @@
 
 namespace KotorPatcher {
     namespace Trampoline {
+        // Displacement a 5-byte E9/E8 at `instructionAddress` needs to reach `target`.
+        // Returns false when the target is too far for a signed 32-bit displacement,
+        // which can only happen on a 64-bit target.
+        bool ComputeRel32(uintptr_t instructionAddress, uintptr_t target, int32_t& outRel);
+
         // Write a 5-byte relative JMP at `address` targeting `target`.
         bool WriteJump(uintptr_t address, void* target);
 

--- a/src/KotorPatcher/include/trampoline.h
+++ b/src/KotorPatcher/include/trampoline.h
@@ -17,20 +17,23 @@
 //
 // The unprotect/write/reprotect and instruction-cache handling live behind
 // Platform::WriteCode, so this module is pure x86 byte layout.
+//
+// Addresses are uintptr_t because the engine dereferences them: 32 bits on the
+// i686/i386 targets, 64 on the macOS x86_64 dylib.
 
 namespace KotorPatcher {
     namespace Trampoline {
         // Write a 5-byte relative JMP at `address` targeting `target`.
-        bool WriteJump(uint32_t address, void* target);
+        bool WriteJump(uintptr_t address, void* target);
 
         // Write a 5-byte relative CALL at `address` targeting `target`.
-        bool WriteCall(uint32_t address, void* target);
+        bool WriteCall(uintptr_t address, void* target);
 
         // Compare `length` bytes at `address` against `expected`. Used as the
         // wrong-game-version guard before any patch is applied.
-        bool VerifyBytes(uint32_t address, const uint8_t* expected, std::size_t length);
+        bool VerifyBytes(uintptr_t address, const uint8_t* expected, std::size_t length);
 
         // Overwrite `length` bytes at `startAddress` with NOPs (0x90).
-        bool WriteNoOps(uint32_t startAddress, std::size_t length);
+        bool WriteNoOps(uintptr_t startAddress, std::size_t length);
     }
 }

--- a/src/KotorPatcher/include/wrappers/wrapper_base.h
+++ b/src/KotorPatcher/include/wrappers/wrapper_base.h
@@ -17,7 +17,7 @@ namespace KotorPatcher {
         struct WrapperConfig {
 
             void* patchFunction;
-            uint32_t hookAddress;
+            uintptr_t hookAddress;
 
             // Original bytes that were overwritten by the hook (for DETOUR type)
             // These will be executed in the wrapper before returning to original code
@@ -52,7 +52,7 @@ namespace KotorPatcher {
             // falls through to the existing original-bytes / skipOriginalBytes
             // path. Caller must add "eax" to excludeFromRestore so the
             // handler's return value reaches the test. Default 0 = disabled.
-            uint32_t consumedExitAddress = 0;
+            uintptr_t consumedExitAddress = 0;
 
             // Original function pointer (future use)
             void* originalFunction = nullptr;

--- a/src/KotorPatcher/include/wrappers/wrapper_x86.h
+++ b/src/KotorPatcher/include/wrappers/wrapper_x86.h
@@ -45,6 +45,10 @@ namespace KotorPatcher {
             void EmitByte(uint8_t*& code, uint8_t value);
             void EmitDword(uint8_t*& code, uint32_t value);
 
+            // Helper: Emit FXSAVE or FXRSTOR through the reserved area above the
+            // saved state, which the caller reaches from EBX
+            void EmitFpStateAccess(uint8_t*& code, int savedStateSize, bool restore);
+
             // Helper: Calculate relative offset for JMP/CALL
             uint32_t CalculateRelativeOffset(void* from, void* to);
 

--- a/src/KotorPatcher/include/wrappers/wrapper_x86.h
+++ b/src/KotorPatcher/include/wrappers/wrapper_x86.h
@@ -35,7 +35,7 @@ namespace KotorPatcher {
             std::vector<AllocatedWrapper> m_allocatedWrappers;
 
             // Allocate executable memory for wrapper code
-            void* AllocateExecutableMemory(size_t size);
+            void* AllocateExecutableMemory(size_t size, uintptr_t nearAddress);
 
             // Generate DETOUR type wrapper (save state, call patch, restore state, execute stolen bytes)
             void* GenerateDetourWrapper(const WrapperConfig& config);

--- a/src/KotorPatcher/include/wrappers/wrapper_x86.h
+++ b/src/KotorPatcher/include/wrappers/wrapper_x86.h
@@ -49,7 +49,7 @@ namespace KotorPatcher {
             uint32_t CalculateRelativeOffset(void* from, void* to);
 
             // Helper: Extract parameter from source and push onto stack
-            void ExtractAndPushParameter(uint8_t*& code, const ParameterInfo& param, int savedStateOffset, int pushCount);
+            void ExtractAndPushParameter(uint8_t*& code, const ParameterInfo& param, int savedStateSize);
         };
 
     } // namespace Wrappers

--- a/src/KotorPatcher/include/wrappers/wrapper_x86_64.h
+++ b/src/KotorPatcher/include/wrappers/wrapper_x86_64.h
@@ -1,0 +1,45 @@
+#pragma once
+#include <cstdint>
+#include "wrapper_base.h"
+
+// x86_64 wrapper generator, for the macOS build of the games.
+//
+// This is not a widened copy of the x86 generator. PUSHAD and POPAD, which that one
+// is built around, are invalid opcodes in long mode, and the System V AMD64 calling
+// convention passes arguments in registers rather than on the stack. The two share
+// only the shape: save the game's state, call the patch function, restore, run the
+// stolen bytes, jump back.
+//
+// KNOWN LIMITATION, and it is the patch author's to respect: stolen bytes are copied
+// into the stub and executed there. x86_64 code can address data relative to RIP, and
+// such an instruction means something different once it has moved. The engine cannot
+// tell, because finding instruction boundaries needs a length disassembler it does not
+// have, so a DETOUR hook whose cut bytes contain a RIP-relative reference will read or
+// write the wrong address. Cut somewhere else.
+
+namespace KotorPatcher {
+    namespace Wrappers {
+
+        class WrapperGenerator_x86_64 : public WrapperGeneratorBase {
+        public:
+            ~WrapperGenerator_x86_64() override;
+
+            void* GenerateWrapper(const WrapperConfig& config) override;
+            void FreeAllWrappers() override;
+
+            const char* GetPlatformName() const override {
+                return "x86_64";
+            }
+
+        private:
+            struct AllocatedWrapper {
+                void* address;
+                std::size_t size;
+            };
+            std::vector<AllocatedWrapper> m_allocatedWrappers;
+
+            void* GenerateDetourWrapper(const WrapperConfig& config);
+        };
+
+    } // namespace Wrappers
+} // namespace KotorPatcher

--- a/src/KotorPatcher/src/core/config_reader.cpp
+++ b/src/KotorPatcher/src/core/config_reader.cpp
@@ -1,6 +1,8 @@
 #include "config_reader.h"
 #include "platform.h"
 
+#include <cerrno>
+#include <cinttypes>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
@@ -14,21 +16,41 @@
 namespace KotorPatcher {
     namespace Config {
 
-        // Helper function to convert hex string to uint32_t
-        static bool ParseHexAddress(const std::string& hexStr, uint32_t& outAddress) {
+        // Helper function to convert a hex string to uint64_t
+        // Width is the caller's problem: this reads both hook addresses and single
+        // bytes out of the original/replacement arrays
+        static bool ParseHexValue(const std::string& hexStr, uint64_t& outValue) {
             std::string cleaned = hexStr;
             if (cleaned.size() >= 2 && cleaned[0] == '0' && (cleaned[1] == 'x' || cleaned[1] == 'X')) {
                 cleaned = cleaned.substr(2);
             }
 
             char* endPtr = nullptr;
-            unsigned long value = strtoul(cleaned.c_str(), &endPtr, 16);
+            errno = 0;
+            unsigned long long value = strtoull(cleaned.c_str(), &endPtr, 16);
 
-            if (endPtr == cleaned.c_str() || *endPtr != '\0') {
+            if (endPtr == cleaned.c_str() || *endPtr != '\0' || errno == ERANGE) {
                 return false; // Parse failed
             }
 
-            outAddress = static_cast<uint32_t>(value);
+            outValue = static_cast<uint64_t>(value);
+            return true;
+        }
+
+        // Helper function to narrow a config address to the target's pointer width
+        // The engine dereferences these, so a 64-bit address reaching the 32-bit
+        // engine means the config is for another build of the game. Reject it rather
+        // than truncate it into a plausible-looking address elsewhere in this image
+        static bool NarrowCodeAddress(uint64_t value, uintptr_t& outAddress, const char* what) {
+            if (value > static_cast<uint64_t>(UINTPTR_MAX)) {
+                char msg[192];
+                snprintf(msg, sizeof(msg),
+                    "[Config] %s 0x%llX does not fit a %zu-bit address\n",
+                    what, static_cast<unsigned long long>(value), sizeof(uintptr_t) * 8);
+                Platform::Log(msg);
+                return false;
+            }
+            outAddress = static_cast<uintptr_t>(value);
             return true;
         }
 
@@ -51,8 +73,8 @@ namespace KotorPatcher {
                 // Or as hex strings like "0x55"
                 else if (elem.is_string()) {
                     std::string hexStr = elem.as_string()->get();
-                    uint32_t byteVal;
-                    if (!ParseHexAddress(hexStr, byteVal) || byteVal > 255) {
+                    uint64_t byteVal;
+                    if (!ParseHexValue(hexStr, byteVal) || byteVal > 255) {
                         Platform::Log(("[Config] Invalid byte string: " + hexStr + "\n").c_str());
                         return false;
                     }
@@ -167,14 +189,21 @@ namespace KotorPatcher {
 
                     if (addressStr) {
                         // Address specified as hex string "0x401234"
-                        if (!ParseHexAddress(*addressStr, patch.hookAddress)) {
+                        uint64_t parsed = 0;
+                        if (!ParseHexValue(*addressStr, parsed)) {
                             Platform::Log(("[Config] Invalid address format: " + *addressStr + "\n").c_str());
+                            continue;
+                        }
+                        if (!NarrowCodeAddress(parsed, patch.hookAddress, "hook address")) {
                             continue;
                         }
                     }
                     else if (addressInt) {
                         // Address specified as integer
-                        patch.hookAddress = static_cast<uint32_t>(*addressInt);
+                        if (!NarrowCodeAddress(static_cast<uint64_t>(*addressInt),
+                                               patch.hookAddress, "hook address")) {
+                            continue;
+                        }
                     }
                     else {
                         Platform::Log("[Config] Hook missing 'address' field\n");
@@ -311,7 +340,7 @@ namespace KotorPatcher {
                     if (skipOrigBytes) {
                         patch.skipOriginalBytes = *skipOrigBytes;
                         char debugMsg[256];
-                        snprintf(debugMsg, sizeof(debugMsg), "[Config] Parsed skip_original_bytes = %s for hook at 0x%08X\n",
+                        snprintf(debugMsg, sizeof(debugMsg), "[Config] Parsed skip_original_bytes = %s for hook at 0x%08" PRIXPTR "\n",
                             *skipOrigBytes ? "true" : "false", patch.hookAddress);
                         Platform::Log(debugMsg);
                     }
@@ -323,16 +352,19 @@ namespace KotorPatcher {
                     auto consumedExitInt = hookTable->at_path("consumed_exit_address").value<int64_t>();
 
                     if (consumedExitStr) {
-                        if (!ParseHexAddress(*consumedExitStr, patch.consumedExitAddress)) {
+                        uint64_t parsed = 0;
+                        if (!ParseHexValue(*consumedExitStr, parsed) ||
+                            !NarrowCodeAddress(parsed, patch.consumedExitAddress, "consumed_exit_address")) {
                             Platform::Log(("[Config] Invalid consumed_exit_address: " + *consumedExitStr + "\n").c_str());
                         }
                     }
                     else if (consumedExitInt) {
-                        patch.consumedExitAddress = static_cast<uint32_t>(*consumedExitInt);
+                        NarrowCodeAddress(static_cast<uint64_t>(*consumedExitInt),
+                                          patch.consumedExitAddress, "consumed_exit_address");
                     }
                     if (patch.consumedExitAddress != 0) {
                         char debugMsg[256];
-                        snprintf(debugMsg, sizeof(debugMsg), "[Config] Parsed consumed_exit_address = 0x%08X for hook at 0x%08X\n",
+                        snprintf(debugMsg, sizeof(debugMsg), "[Config] Parsed consumed_exit_address = 0x%08" PRIXPTR " for hook at 0x%08" PRIXPTR "\n",
                             patch.consumedExitAddress, patch.hookAddress);
                         Platform::Log(debugMsg);
                     }
@@ -371,11 +403,11 @@ namespace KotorPatcher {
                     // Debug message
                     char debugMsg[256];
                     if (patch.type == HookType::SIMPLE) {
-                        snprintf(debugMsg, sizeof(debugMsg), "[Config] Loaded SIMPLE hook: %s @ 0x%08X (%zu bytes)\n",
+                        snprintf(debugMsg, sizeof(debugMsg), "[Config] Loaded SIMPLE hook: %s @ 0x%08" PRIXPTR " (%zu bytes)\n",
                             patchId.c_str(), patch.hookAddress, patch.originalBytes.size());
                     }
                     else {
-                        snprintf(debugMsg, sizeof(debugMsg), "[Config] Loaded DETOUR hook: %s -> %s @ 0x%08X (%zu bytes)\n",
+                        snprintf(debugMsg, sizeof(debugMsg), "[Config] Loaded DETOUR hook: %s -> %s @ 0x%08" PRIXPTR " (%zu bytes)\n",
                             patchId.c_str(), patch.functionName.c_str(),
                             patch.hookAddress, patch.originalBytes.size());
                     }

--- a/src/KotorPatcher/src/core/config_reader.cpp
+++ b/src/KotorPatcher/src/core/config_reader.cpp
@@ -416,8 +416,12 @@ namespace KotorPatcher {
             }
 
             if (outPatches.empty()) {
-                Platform::Log("[Config] Warning: No patches found in config\n");
-                return false;
+                // Nothing to do at runtime is a normal install, not a broken config. A patch
+                // made only of STATIC hooks reaches the game by editing the executable, and
+                // ConfigGenerator leaves those hooks out of this file, so a config listing
+                // only such patches has no entries by design.
+                Platform::Log("[Config] No runtime hooks in config; nothing to apply\n");
+                return true;
             }
 
             char successMsg[128];

--- a/src/KotorPatcher/src/core/config_reader.cpp
+++ b/src/KotorPatcher/src/core/config_reader.cpp
@@ -401,15 +401,19 @@ namespace KotorPatcher {
                     outPatches.push_back(patch);
 
                     // Debug message
+                    // Only DETOUR names a function to call; the others would print an
+                    // empty one, which is how a REPLACE hook used to be reported as a
+                    // DETOUR with no target.
                     char debugMsg[256];
-                    if (patch.type == HookType::SIMPLE) {
-                        snprintf(debugMsg, sizeof(debugMsg), "[Config] Loaded SIMPLE hook: %s @ 0x%08" PRIXPTR " (%zu bytes)\n",
-                            patchId.c_str(), patch.hookAddress, patch.originalBytes.size());
-                    }
-                    else {
+                    if (patch.type == HookType::DETOUR) {
                         snprintf(debugMsg, sizeof(debugMsg), "[Config] Loaded DETOUR hook: %s -> %s @ 0x%08" PRIXPTR " (%zu bytes)\n",
                             patchId.c_str(), patch.functionName.c_str(),
                             patch.hookAddress, patch.originalBytes.size());
+                    }
+                    else {
+                        snprintf(debugMsg, sizeof(debugMsg), "[Config] Loaded %s hook: %s @ 0x%08" PRIXPTR " (%zu bytes)\n",
+                            patch.type == HookType::SIMPLE ? "SIMPLE" : "REPLACE",
+                            patchId.c_str(), patch.hookAddress, patch.originalBytes.size());
                     }
                     Platform::Log(debugMsg);
                 }

--- a/src/KotorPatcher/src/core/patcher.cpp
+++ b/src/KotorPatcher/src/core/patcher.cpp
@@ -331,7 +331,7 @@ namespace KotorPatcher {
         std::size_t bufferSize = patch.replacementBytes.size() + 5;
 
         // Allocate executable memory for replacement code + return JMP
-        void* codeBuf = Platform::AllocExec(bufferSize);
+        void* codeBuf = Platform::AllocExec(bufferSize, patch.hookAddress);
         if (!codeBuf) {
             Platform::Log("[KotorPatcher] Failed to allocate memory for REPLACE hook\n");
             return false;

--- a/src/KotorPatcher/src/core/patcher.cpp
+++ b/src/KotorPatcher/src/core/patcher.cpp
@@ -348,9 +348,15 @@ namespace KotorPatcher {
 
         // Write JMP back to game code at end of replacement bytes
         uint8_t* returnJmp = static_cast<uint8_t*>(codeBuf) + patch.replacementBytes.size();
+        int32_t offset = 0;
+        if (!Trampoline::ComputeRel32(reinterpret_cast<uintptr_t>(returnJmp),
+                                      reinterpret_cast<uintptr_t>(returnAddr), offset)) {
+            // AllocExec places the block wherever the kernel likes, which on a 64-bit
+            // target can be further than a rel32 from the game image.
+            Platform::Log("[KotorPatcher] REPLACE code block is out of rel32 range of the game\n");
+            return false;
+        }
         *returnJmp = 0xE9;  // JMP opcode
-        int32_t offset = static_cast<int32_t>(
-            reinterpret_cast<uintptr_t>(returnAddr) - (reinterpret_cast<uintptr_t>(returnJmp) + 5));
         std::memcpy(returnJmp + 1, &offset, 4);
 
         // Flush instruction cache for code buffer

--- a/src/KotorPatcher/src/core/patcher.cpp
+++ b/src/KotorPatcher/src/core/patcher.cpp
@@ -340,7 +340,7 @@ namespace KotorPatcher {
         // Track allocated buffer for cleanup
         g_allocatedCodeBuffers.push_back({ codeBuf, bufferSize });
 
-        // Write replacement bytes to allocated memory (already writable+executable)
+        // Write replacement bytes to allocated memory (not executable until ProtectExec)
         std::memcpy(codeBuf, patch.replacementBytes.data(), patch.replacementBytes.size());
 
         // Calculate return address (after original bytes)
@@ -359,8 +359,10 @@ namespace KotorPatcher {
         *returnJmp = 0xE9;  // JMP opcode
         std::memcpy(returnJmp + 1, &offset, 4);
 
-        // Flush instruction cache for code buffer
-        Platform::FlushICache(codeBuf, bufferSize);
+        if (!Platform::ProtectExec(codeBuf, bufferSize)) {
+            Platform::Log("[KotorPatcher] Failed to make the REPLACE code block executable\n");
+            return false;
+        }
 
         // Write JMP at hook address to code buffer
         if (!Trampoline::WriteJump(patch.hookAddress, codeBuf)) {

--- a/src/KotorPatcher/src/core/patcher.cpp
+++ b/src/KotorPatcher/src/core/patcher.cpp
@@ -5,6 +5,7 @@
 #include "wrapper_base.h"
 
 #include <chrono>
+#include <cinttypes>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
@@ -223,14 +224,14 @@ namespace KotorPatcher {
         }
 
         char addrMsg[256];
-        snprintf(addrMsg, sizeof(addrMsg), "[KotorPatcher] Symbol resolved: %s at 0x%08X\n",
-            patch.functionName.c_str(), reinterpret_cast<uint32_t>(funcAddr));
+        snprintf(addrMsg, sizeof(addrMsg), "[KotorPatcher] Symbol resolved: %s at 0x%08" PRIXPTR "\n",
+            patch.functionName.c_str(), reinterpret_cast<uintptr_t>(funcAddr));
         Platform::Log(addrMsg);
 
         // Verify original bytes
         if (!Trampoline::VerifyBytes(patch.hookAddress, patch.originalBytes.data(), patch.originalBytes.size())) {
             char errorMsg[256];
-            snprintf(errorMsg, sizeof(errorMsg), "[KotorPatcher] Original bytes mismatch at hookAddress 0x%08X - wrong game version?\n", patch.hookAddress);
+            snprintf(errorMsg, sizeof(errorMsg), "[KotorPatcher] Original bytes mismatch at hookAddress 0x%08" PRIXPTR " - wrong game version?\n", patch.hookAddress);
             Platform::Log(errorMsg);
             return false;
         }
@@ -282,7 +283,7 @@ namespace KotorPatcher {
         }
 
         char successMsg[256];
-        snprintf(successMsg, sizeof(successMsg), "[KotorPatcher] Applied DETOUR hook at 0x%08X -> %s\n",
+        snprintf(successMsg, sizeof(successMsg), "[KotorPatcher] Applied DETOUR hook at 0x%08" PRIXPTR " -> %s\n",
             patch.hookAddress,
             patch.functionName.c_str());
         Platform::Log(successMsg);
@@ -295,7 +296,7 @@ namespace KotorPatcher {
         // Verify original bytes
         if (!Trampoline::VerifyBytes(patch.hookAddress, patch.originalBytes.data(), patch.originalBytes.size())) {
             char errorMsg[256];
-            snprintf(errorMsg, sizeof(errorMsg), "[KotorPatcher] Original bytes mismatch at hookAddress 0x%08X - wrong game version?\n", patch.hookAddress);
+            snprintf(errorMsg, sizeof(errorMsg), "[KotorPatcher] Original bytes mismatch at hookAddress 0x%08" PRIXPTR " - wrong game version?\n", patch.hookAddress);
             Platform::Log(errorMsg);
             return false;
         }
@@ -308,7 +309,7 @@ namespace KotorPatcher {
         }
 
         char successMsg[256];
-        snprintf(successMsg, sizeof(successMsg), "[KotorPatcher] Applied SIMPLE hook at 0x%08X (%zu bytes replaced)\n",
+        snprintf(successMsg, sizeof(successMsg), "[KotorPatcher] Applied SIMPLE hook at 0x%08" PRIXPTR " (%zu bytes replaced)\n",
             patch.hookAddress,
             patch.replacementBytes.size());
         Platform::Log(successMsg);
@@ -321,7 +322,7 @@ namespace KotorPatcher {
         // Verify original bytes
         if (!Trampoline::VerifyBytes(patch.hookAddress, patch.originalBytes.data(), patch.originalBytes.size())) {
             char errorMsg[256];
-            snprintf(errorMsg, sizeof(errorMsg), "[KotorPatcher] Original bytes mismatch at hookAddress 0x%08X - wrong game version?\n", patch.hookAddress);
+            snprintf(errorMsg, sizeof(errorMsg), "[KotorPatcher] Original bytes mismatch at hookAddress 0x%08" PRIXPTR " - wrong game version?\n", patch.hookAddress);
             Platform::Log(errorMsg);
             return false;
         }
@@ -348,7 +349,8 @@ namespace KotorPatcher {
         // Write JMP back to game code at end of replacement bytes
         uint8_t* returnJmp = static_cast<uint8_t*>(codeBuf) + patch.replacementBytes.size();
         *returnJmp = 0xE9;  // JMP opcode
-        uint32_t offset = reinterpret_cast<uint32_t>(returnAddr) - (reinterpret_cast<uint32_t>(returnJmp) + 5);
+        int32_t offset = static_cast<int32_t>(
+            reinterpret_cast<uintptr_t>(returnAddr) - (reinterpret_cast<uintptr_t>(returnJmp) + 5));
         std::memcpy(returnJmp + 1, &offset, 4);
 
         // Flush instruction cache for code buffer
@@ -369,7 +371,7 @@ namespace KotorPatcher {
         }
 
         char successMsg[256];
-        snprintf(successMsg, sizeof(successMsg), "[KotorPatcher] Applied REPLACE hook at 0x%08X (%zu bytes code, %zu bytes replaced)\n",
+        snprintf(successMsg, sizeof(successMsg), "[KotorPatcher] Applied REPLACE hook at 0x%08" PRIXPTR " (%zu bytes code, %zu bytes replaced)\n",
             patch.hookAddress,
             patch.replacementBytes.size(),
             patch.originalBytes.size());

--- a/src/KotorPatcher/src/core/trampoline.cpp
+++ b/src/KotorPatcher/src/core/trampoline.cpp
@@ -6,14 +6,12 @@
 
 // SIMPLE 5-byte relative JMP trampolines that replace the instructions at the
 // hook point. The unprotect/write/reprotect and instruction-cache handling live
-// in Platform::WriteCode, so this file is pure x86 byte layout. Both targets are
-// 32-bit, so a code address fits a uint32_t and reinterpret_cast to/from it
-// loses nothing.
+// in Platform::WriteCode, so this file is pure x86 byte layout.
 
 namespace KotorPatcher {
     namespace Trampoline {
 
-        bool VerifyBytes(uint32_t address, const uint8_t* expected, std::size_t length) {
+        bool VerifyBytes(uintptr_t address, const uint8_t* expected, std::size_t length) {
             if (!expected || length == 0) {
                 return false;
             }
@@ -21,7 +19,7 @@ namespace KotorPatcher {
             return std::memcmp(actual, expected, length) == 0;
         }
 
-        bool WriteNoOps(uint32_t startAddress, std::size_t length) {
+        bool WriteNoOps(uintptr_t startAddress, std::size_t length) {
             if (length == 0) {
                 // Nothing to do; the hook fit exactly in 5 bytes.
                 return true;
@@ -34,10 +32,11 @@ namespace KotorPatcher {
             return true;
         }
 
-        bool WriteJump(uint32_t address, void* target) {
+        bool WriteJump(uintptr_t address, void* target) {
             // E9 <rel32>, where rel32 = target - (address + 5). The +5 is the size
             // of the instruction the CPU has already consumed when it reads rel32.
-            uint32_t offset = reinterpret_cast<uint32_t>(target) - (address + 5);
+            int32_t offset = static_cast<int32_t>(
+                reinterpret_cast<uintptr_t>(target) - (address + 5));
             uint8_t jmp[5];
             jmp[0] = 0xE9;
             std::memcpy(&jmp[1], &offset, 4);
@@ -48,9 +47,10 @@ namespace KotorPatcher {
             return true;
         }
 
-        bool WriteCall(uint32_t address, void* target) {
+        bool WriteCall(uintptr_t address, void* target) {
             // E8 <rel32>: like WriteJump but pushes a return address first.
-            uint32_t offset = reinterpret_cast<uint32_t>(target) - (address + 5);
+            int32_t offset = static_cast<int32_t>(
+                reinterpret_cast<uintptr_t>(target) - (address + 5));
             uint8_t call[5];
             call[0] = 0xE8;
             std::memcpy(&call[1], &offset, 4);

--- a/src/KotorPatcher/src/core/trampoline.cpp
+++ b/src/KotorPatcher/src/core/trampoline.cpp
@@ -32,11 +32,29 @@ namespace KotorPatcher {
             return true;
         }
 
+        bool ComputeRel32(uintptr_t instructionAddress, uintptr_t target, int32_t& outRel) {
+            // The +5 is the size of the instruction the CPU has already consumed when
+            // it reads rel32. Deliberately subtracted in uintptr_t so the arithmetic
+            // wraps in the target's pointer width, as the CPU's does.
+            uintptr_t delta = target - (instructionAddress + 5);
+            int32_t rel = static_cast<int32_t>(delta);
+
+            // The CPU sign-extends rel32 before adding it, so the jump lands on `target`
+            // only when that sign extension gives the delta back. Always true at 32 bits.
+            if (static_cast<uintptr_t>(static_cast<intptr_t>(rel)) != delta) {
+                return false;
+            }
+
+            outRel = rel;
+            return true;
+        }
+
         bool WriteJump(uintptr_t address, void* target) {
-            // E9 <rel32>, where rel32 = target - (address + 5). The +5 is the size
-            // of the instruction the CPU has already consumed when it reads rel32.
-            int32_t offset = static_cast<int32_t>(
-                reinterpret_cast<uintptr_t>(target) - (address + 5));
+            int32_t offset = 0;
+            if (!ComputeRel32(address, reinterpret_cast<uintptr_t>(target), offset)) {
+                Platform::Log("[Trampoline] JMP target is out of rel32 range\n");
+                return false;
+            }
             uint8_t jmp[5];
             jmp[0] = 0xE9;
             std::memcpy(&jmp[1], &offset, 4);
@@ -49,8 +67,11 @@ namespace KotorPatcher {
 
         bool WriteCall(uintptr_t address, void* target) {
             // E8 <rel32>: like WriteJump but pushes a return address first.
-            int32_t offset = static_cast<int32_t>(
-                reinterpret_cast<uintptr_t>(target) - (address + 5));
+            int32_t offset = 0;
+            if (!ComputeRel32(address, reinterpret_cast<uintptr_t>(target), offset)) {
+                Platform::Log("[Trampoline] CALL target is out of rel32 range\n");
+                return false;
+            }
             uint8_t call[5];
             call[0] = 0xE8;
             std::memcpy(&call[1], &offset, 4);

--- a/src/KotorPatcher/src/core/wrapper_x86.cpp
+++ b/src/KotorPatcher/src/core/wrapper_x86.cpp
@@ -80,21 +80,22 @@ namespace KotorPatcher {
             uint8_t* code = wrapperMem;  // Current write position
 
             // ===== PROLOGUE: Save CPU State =====
+            // We always save, whatever preserveRegisters and preserveFlags say. Those
+            // decide what gets written back, not what gets kept:
+            // 1. A parameter sourced from a register reads the saved copy, so it has
+            //    to exist even when nothing is restored
+            // 2. EBX below becomes our anchor, so the game's EBX must be somewhere
 
-            if (config.preserveRegisters) {
-                // PUSHAD: Push all general-purpose registers
-                // Order: EAX, ECX, EDX, EBX, ESP, EBP, ESI, EDI
-                EmitByte(code, 0x60);  // PUSHAD
-            }
+            // PUSHAD: Push all general-purpose registers
+            // Order: EAX, ECX, EDX, EBX, ESP, EBP, ESI, EDI
+            EmitByte(code, 0x60);  // PUSHAD
 
-            if (config.preserveFlags) {
-                // PUSHFD: Push EFLAGS register
-                EmitByte(code, 0x9C);  // PUSHFD
-            }
+            // PUSHFD: Push EFLAGS register
+            EmitByte(code, 0x9C);  // PUSHFD
 
             // ===== CALCULATE STACK LAYOUT =====
             // At this point, the stack layout is:
-            // [ESP+0]  = EFLAGS (if preserveFlags)
+            // [ESP+0]  = EFLAGS
             // [ESP+4]  = EDI    \
             // [ESP+8]  = ESI     |
             // [ESP+12] = EBP     |
@@ -103,13 +104,12 @@ namespace KotorPatcher {
             // [ESP+24] = EDX     |
             // [ESP+28] = ECX     |
             // [ESP+32] = EAX    /
-            // [ESP+36] = Return address (from game's CALL to hook)
-            // [ESP+40] = Original stack data (parameters, etc.)
+            // [ESP+36] = Original stack data (parameters, etc.)
+            // The hook site is reached by a JMP, not a CALL, so there is no return
+            // address in between
 
-            // Calculate total bytes we've pushed onto the stack
-            int savedStateSize = 0;
-            if (config.preserveFlags) savedStateSize += 4;      // PUSHFD
-            if (config.preserveRegisters) savedStateSize += 32; // PUSHAD
+            // Total bytes pushed onto the stack
+            const int savedStateSize = 4 + 32;  // PUSHFD + PUSHAD
 
             // Save current ESP to EBX (points to our saved state)
             // We'll use this to read saved registers and restore ESP later
@@ -179,11 +179,18 @@ namespace KotorPatcher {
             if (config.preserveFlags) {
                 // POPFD: Restore EFLAGS
                 EmitByte(code, 0x9D);  // POPFD
+            } else {
+                // Step past the saved EFLAGS without applying them
+                // LEA ESP, [ESP+4]: ADD would set the flags we are declining to restore
+                EmitByte(code, 0x8D);  // LEA r32, m
+                EmitByte(code, 0x64);  // ModRM: ESP, [ESP+disp8] (SIB follows)
+                EmitByte(code, 0x24);  // SIB: [ESP]
+                EmitByte(code, 0x04);  // disp8 = 4
             }
 
-            if (config.preserveRegisters) {
+            {
                 // Handle register exclusions
-                if (config.excludeFromRestore.empty()) {
+                if (config.preserveRegisters && config.excludeFromRestore.empty()) {
                     // Simple case: restore all registers
                     EmitByte(code, 0x61);  // POPAD
                 } else {
@@ -194,6 +201,7 @@ namespace KotorPatcher {
                     const char* regOrder[] = { "edi", "esi", "ebp", "esp", "ebx", "edx", "ecx", "eax" };
                     const uint8_t popOpcodes[] = { 0x5F, 0x5E, 0x5D, 0x5C, 0x5B, 0x5A, 0x59, 0x58 };
                     constexpr int kEspSlot = 3;
+                    constexpr int kEbxSlot = 4;
 
                     for (int i = 0; i < 8; i++) {
                         // Hardware POPAD never restores ESP — it just advances
@@ -202,7 +210,13 @@ namespace KotorPatcher {
                         // past the remaining EBX/EDX/ECX/EAX slots and reading
                         // them from random stack memory. Always skip the ESP
                         // slot regardless of exclude_from_restore.
-                        if (i != kEspSlot && config.ShouldRestoreRegister(regOrder[i])) {
+                        // EBX is always restored. The wrapper commandeered it as its
+                        // anchor, so the patch function never had a say in its value:
+                        // leaving it out would hand the game one of our stack addresses,
+                        // not anything the patch chose. Excluding "ebx" cannot mean
+                        // anything, so it is ignored rather than obeyed.
+                        if (i != kEspSlot &&
+                            (i == kEbxSlot || config.ShouldRestoreRegister(regOrder[i]))) {
                             EmitByte(code, popOpcodes[i]);  // POP reg
                         } else {
                             // Skip this register (matches POPAD's ESP semantics

--- a/src/KotorPatcher/src/core/wrapper_x86.cpp
+++ b/src/KotorPatcher/src/core/wrapper_x86.cpp
@@ -17,8 +17,8 @@ namespace KotorPatcher {
             FreeAllWrappers();
         }
 
-        void* WrapperGenerator_x86::AllocateExecutableMemory(size_t size) {
-            void* mem = Platform::AllocExec(size);
+        void* WrapperGenerator_x86::AllocateExecutableMemory(size_t size, uintptr_t nearAddress) {
+            void* mem = Platform::AllocExec(size, nearAddress);
             if (mem) {
                 m_allocatedWrappers.push_back({ mem, size });
             }
@@ -65,7 +65,10 @@ namespace KotorPatcher {
                 estimatedSize += 16;
             }
 
-            uint8_t* wrapperMem = static_cast<uint8_t*>(AllocateExecutableMemory(estimatedSize));
+            // The hook site jumps here and the wrapper jumps back, so the stub has to
+            // land within a relative jump of the code it is hooking.
+            uint8_t* wrapperMem = static_cast<uint8_t*>(
+                AllocateExecutableMemory(estimatedSize, config.hookAddress));
             if (!wrapperMem) {
                 Platform::Log("[Wrapper] Failed to allocate wrapper memory\n");
                 return nullptr;

--- a/src/KotorPatcher/src/core/wrapper_x86.cpp
+++ b/src/KotorPatcher/src/core/wrapper_x86.cpp
@@ -60,7 +60,10 @@ namespace KotorPatcher {
             // Estimate wrapper size
             // Base: ~100 bytes, +10 per excluded register, +16 for the
             // consumed-exit conditional (12 bytes emitted, padded to 16)
-            size_t estimatedSize = 128 + (config.excludeFromRestore.size() * 10);
+            // Original bytes are copied into the stub verbatim, so they are counted
+            // here rather than left to the base's headroom
+            size_t estimatedSize = 128 + config.originalBytes.size() +
+                                   (config.excludeFromRestore.size() * 10);
             if (config.consumedExitAddress != 0) {
                 estimatedSize += 16;
             }
@@ -114,22 +117,42 @@ namespace KotorPatcher {
             EmitByte(code, 0x89);  // MOV r/m32, r32
             EmitByte(code, 0xE3);  // ModRM: EBX = ESP
 
-            // IMPORTANT: We do NOT modify ESP here!
-            // If we did, PUSH instructions would overwrite our saved registers.
-            // Instead, we'll read parameters with adjusted offsets (see ExtractAndPushParameter)
+            // ===== ALIGN THE STACK FOR THE CALL =====
+            // IMPORTANT: this is where ESP starts moving.
+            // AND only rounds down, so the saved state stays above ESP and the
+            // parameter pushes land below it. ExtractAndPushParameter reads from
+            // EBX for that reason: ESP no longer points at the saved state.
+            //
+            // We align unconditionally because we cannot know what compiled the
+            // patch DLL. MSVC and MinGW realign in their own prologue; GCC
+            // targeting Linux or macOS assumes the caller did it and emits an
+            // aligned move regardless. A hook site is an arbitrary instruction in
+            // the game, so it promises neither.
+            //
+            // AND and SUB write EFLAGS. That is already given up here: with
+            // preserveFlags the state was saved above and is restored below, and
+            // without it the CALL clobbers the flags anyway.
+            const int paramBytes = static_cast<int>(config.parameters.size()) * 4;
+            const int alignmentPad = (16 - (paramBytes % 16)) % 16;
+
+            // AND ESP, -16
+            EmitByte(code, 0x83);  // AND r/m32, imm8
+            EmitByte(code, 0xE4);  // ModRM: ESP
+            EmitByte(code, 0xF0);  // imm8: -16
+
+            if (alignmentPad != 0) {
+                // SUB ESP, alignmentPad: leaves the pushes ending on a boundary
+                EmitByte(code, 0x83);  // SUB r/m32, imm8
+                EmitByte(code, 0xEC);  // ModRM: ESP
+                EmitByte(code, static_cast<uint8_t>(alignmentPad));
+            }
 
             // ===== EXTRACT AND PUSH PARAMETERS =====
             // If the hook has parameters defined, extract them and push onto stack
             // Parameters are pushed in reverse order for __cdecl (right-to-left)
 
-            if (!config.parameters.empty()) {
-                // Push parameters in reverse order (last parameter first)
-                int pushCount = 0;
-                for (int i = static_cast<int>(config.parameters.size()) - 1; i >= 0; i--) {
-                    const auto& param = config.parameters[i];
-                    ExtractAndPushParameter(code, param, savedStateSize, pushCount);
-                    pushCount++;
-                }
+            for (int i = static_cast<int>(config.parameters.size()) - 1; i >= 0; i--) {
+                ExtractAndPushParameter(code, config.parameters[i], savedStateSize);
             }
 
             // ===== CALL PATCH FUNCTION =====
@@ -143,23 +166,10 @@ namespace KotorPatcher {
             uint32_t callOffset = CalculateRelativeOffset(code - 1, config.patchFunction);
             EmitDword(code, callOffset);
 
-            // ===== CLEAN UP PARAMETERS =====
-            // For __cdecl, caller cleans up the stack
-            if (!config.parameters.empty()) {
-                int paramBytes = static_cast<int>(config.parameters.size()) * 4;
-                if (paramBytes <= 127) {
-                    EmitByte(code, 0x83);  // ADD ESP, imm8
-                    EmitByte(code, 0xC4);
-                    EmitByte(code, static_cast<uint8_t>(paramBytes));
-                } else {
-                    EmitByte(code, 0x81);  // ADD ESP, imm32
-                    EmitByte(code, 0xC4);
-                    EmitDword(code, paramBytes);
-                }
-            }
-
             // ===== RESTORE WRAPPER ESP =====
             // Restore ESP back to point to our saved state
+            // This also undoes the alignment, the pad and the pushed parameters,
+            // so __cdecl's caller-side cleanup is not emitted separately
             // MOV ESP, EBX
             EmitByte(code, 0x89);  // MOV r/m32, r32
             EmitByte(code, 0xDC);  // ModRM: ESP = EBX
@@ -304,7 +314,7 @@ namespace KotorPatcher {
 
         // ===== Parameter Extraction =====
 
-        void WrapperGenerator_x86::ExtractAndPushParameter(uint8_t*& code, const ParameterInfo& param, int savedStateSize, int pushCount) {
+        void WrapperGenerator_x86::ExtractAndPushParameter(uint8_t*& code, const ParameterInfo& param, int savedStateSize) {
             // Stack layout constants (relative to EBX, which points to saved state)
             // EBX points to where ESP was after PUSHAD/PUSHFD
             //
@@ -317,9 +327,10 @@ namespace KotorPatcher {
             const int OFFSET_ECX    = 28;  // [EBX+28] = ECX
             const int OFFSET_EAX    = 32;  // [EBX+32] = EAX
 
-            // Original stack data (parameters, return address, etc.) is at:
-            // [ESP + savedStateSize + 4]
-            // The +4 accounts for the return address pushed by the game's CALL instruction
+            // Original stack data (parameters, etc.) is at:
+            // [EBX + savedStateSize]
+            // The hook site is reached by a JMP, not a CALL, so there is no return
+            // address in between
             const int STACK_OFFSET_TO_ORIGINAL_DATA = savedStateSize;
 
             std::string source = param.source;
@@ -391,31 +402,27 @@ namespace KotorPatcher {
                     return;
                 }
 
-                // Calculate the actual offset from current ESP
-                // ESP still points to saved state, so we need to account for:
+                // Calculate the actual offset from EBX, not ESP
+                // ESP has moved by the alignment, its pad, and every push before
+                // this one. EBX still points at the saved state, so:
                 // 1. The saved state size (PUSHAD + PUSHFD)
-                // 2. The return address (+4)
-                // 3. The user's requested offset
-                // 4. 4 times the number of push instructions before this one
-                int actualOffset = STACK_OFFSET_TO_ORIGINAL_DATA + userOffset + pushCount * 4;
+                // 2. The user's requested offset
+                int actualOffset = STACK_OFFSET_TO_ORIGINAL_DATA + userOffset;
 
-                // Generate LEA ECX, [ESP + actualOffset]
+                // Generate LEA ECX, [EBX + actualOffset]
                 if (actualOffset == 0) {
-                    // LEA ECX, [ESP]
+                    // LEA ECX, [EBX]
                     EmitByte(code, 0x8D);  // LEA r32, m
-                    EmitByte(code, 0x0C);  // ModRM: ECX, [ESP]
-                    EmitByte(code, 0x24);  // SIB: [ESP]
+                    EmitByte(code, 0x0B);  // ModRM: ECX, [EBX]
                 } else if (actualOffset >= -128 && actualOffset <= 127) {
-                    // LEA ECX, [ESP + imm8]
+                    // LEA ECX, [EBX + imm8]
                     EmitByte(code, 0x8D);  // LEA r32, m
-                    EmitByte(code, 0x4C);  // ModRM: ECX, [ESP + disp8]
-                    EmitByte(code, 0x24);  // SIB: [ESP]
+                    EmitByte(code, 0x4B);  // ModRM: ECX, [EBX + disp8]
                     EmitByte(code, static_cast<uint8_t>(actualOffset));
                 } else {
-                    // LEA ECX, [ESP + imm32]
+                    // LEA ECX, [EBX + imm32]
                     EmitByte(code, 0x8D);  // LEA r32, m
-                    EmitByte(code, 0x8C);  // ModRM: ECX, [ESP + disp32]
-                    EmitByte(code, 0x24);  // SIB: [ESP]
+                    EmitByte(code, 0x8B);  // ModRM: ECX, [EBX + disp32]
                     EmitDword(code, actualOffset);
                 }
                 EmitByte(code, 0x51);  // PUSH ECX

--- a/src/KotorPatcher/src/core/wrapper_x86.cpp
+++ b/src/KotorPatcher/src/core/wrapper_x86.cpp
@@ -9,6 +9,11 @@
 
 namespace KotorPatcher {
     namespace Wrappers {
+        // FXSAVE writes 512 bytes and needs a 16-byte aligned destination, so the
+        // reserved area carries enough slack to find one wherever the game's ESP
+        // happened to be. Present on every CPU with SSE, which these games require.
+        constexpr int kFpSaveSize = 512;
+        constexpr int kFpAreaSize = kFpSaveSize + 16;
 
         WrapperGenerator_x86::WrapperGenerator_x86() {
         }
@@ -46,6 +51,36 @@ namespace KotorPatcher {
             code += 4;
         }
 
+        void WrapperGenerator_x86::EmitFpStateAccess(uint8_t*& code, int savedStateSize, bool restore) {
+            // EAX is borrowed and given back. On the way out it still holds the
+            // handler's return value, which the consumed-exit test is about to read,
+            // and which the caller was told to exclude from restore so it survives.
+            EmitByte(code, 0x50);  // PUSH EAX
+
+            // LEA EAX, [EBX + savedStateSize]: the FXSAVE area sits just above the
+            // pushed state, and EBX is what still points at it
+            EmitByte(code, 0x8D);  // LEA r32, m
+            EmitByte(code, 0x83);  // ModRM: EAX, [EBX + disp32]
+            EmitDword(code, static_cast<uint32_t>(savedStateSize));
+
+            // Round the address up to the 16-byte boundary FXSAVE requires.
+            // ADD and AND write EFLAGS, which is why both callers emit this while
+            // the flags are saved.
+            EmitByte(code, 0x83);  // ADD r/m32, imm8
+            EmitByte(code, 0xC0);  // ModRM: EAX
+            EmitByte(code, 0x0F);  // imm8: 15
+
+            EmitByte(code, 0x83);  // AND r/m32, imm8
+            EmitByte(code, 0xE0);  // ModRM: EAX
+            EmitByte(code, 0xF0);  // imm8: -16
+
+            EmitByte(code, 0x0F);  // FXSAVE / FXRSTOR
+            EmitByte(code, 0xAE);
+            EmitByte(code, restore ? 0x08 : 0x00);  // ModRM: [EAX], /1 restore or /0 save
+
+            EmitByte(code, 0x58);  // POP EAX
+        }
+
         uint32_t WrapperGenerator_x86::CalculateRelativeOffset(void* from, void* to) {
             // For relative JMP/CALL: offset = target - (source + 5)
             // The +5 accounts for the instruction size (1 byte opcode + 4 byte offset)
@@ -62,7 +97,8 @@ namespace KotorPatcher {
             // consumed-exit conditional (12 bytes emitted, padded to 16)
             // Original bytes are copied into the stub verbatim, so they are counted
             // here rather than left to the base's headroom
-            size_t estimatedSize = 128 + config.originalBytes.size() +
+            // +40 for the two FXSAVE sequences and the two frame adjustments
+            size_t estimatedSize = 168 + config.originalBytes.size() +
                                    (config.excludeFromRestore.size() * 10);
             if (config.consumedExitAddress != 0) {
                 estimatedSize += 16;
@@ -80,6 +116,16 @@ namespace KotorPatcher {
             uint8_t* code = wrapperMem;  // Current write position
 
             // ===== PROLOGUE: Save CPU State =====
+            // Room for the floating-point state first, before anything is pushed.
+            // FXSAVE writes 512 bytes to a 16-byte aligned address; nothing is known
+            // about the game's ESP, so the area carries 15 bytes of slack and the
+            // aligned address inside it is worked out below, once EAX is free.
+            // LEA ESP, [ESP - kFpAreaSize]
+            EmitByte(code, 0x8D);  // LEA r32, m
+            EmitByte(code, 0xA4);  // ModRM: ESP, [ESP + disp32] (SIB follows)
+            EmitByte(code, 0x24);  // SIB: [ESP]
+            EmitDword(code, static_cast<uint32_t>(-kFpAreaSize));
+
             // We always save, whatever preserveRegisters and preserveFlags say. Those
             // decide what gets written back, not what gets kept:
             // 1. A parameter sourced from a register reads the saved copy, so it has
@@ -104,7 +150,8 @@ namespace KotorPatcher {
             // [ESP+24] = EDX     |
             // [ESP+28] = ECX     |
             // [ESP+32] = EAX    /
-            // [ESP+36] = Original stack data (parameters, etc.)
+            // [ESP+36] = FXSAVE area, plus its alignment slack
+            // [ESP+564] = Original stack data (parameters, etc.)
             // The hook site is reached by a JMP, not a CALL, so there is no return
             // address in between
 
@@ -116,6 +163,12 @@ namespace KotorPatcher {
             // MOV EBX, ESP
             EmitByte(code, 0x89);  // MOV r/m32, r32
             EmitByte(code, 0xE3);  // ModRM: EBX = ESP
+
+            // ===== SAVE FLOATING-POINT STATE =====
+            // Everything FXSAVE covers is the patch function's to destroy: the x87
+            // stack these games do their float work on, its control word, MMX, and
+            // XMM with MXCSR. None of it is in PUSHAD.
+            EmitFpStateAccess(code, savedStateSize, /*restore=*/false);
 
             // ===== ALIGN THE STACK FOR THE CALL =====
             // IMPORTANT: this is where ESP starts moving.
@@ -175,6 +228,12 @@ namespace KotorPatcher {
             EmitByte(code, 0xDC);  // ModRM: ESP = EBX
 
             // ===== EPILOGUE: Restore CPU State =====
+
+            // Ahead of the flags, because addressing the area writes them, and ahead
+            // of POPAD, because it needs EAX
+            if (config.preserveRegisters) {
+                EmitFpStateAccess(code, savedStateSize, /*restore=*/true);
+            }
 
             if (config.preserveFlags) {
                 // POPFD: Restore EFLAGS
@@ -237,6 +296,14 @@ namespace KotorPatcher {
                     }
                 }
             }
+
+            // ===== CLOSE THE FRAME =====
+            // Step past the FXSAVE area, back to the game's own ESP
+            // LEA ESP, [ESP + kFpAreaSize]
+            EmitByte(code, 0x8D);  // LEA r32, m
+            EmitByte(code, 0xA4);  // ModRM: ESP, [ESP + disp32] (SIB follows)
+            EmitByte(code, 0x24);  // SIB: [ESP]
+            EmitDword(code, kFpAreaSize);
 
             // ===== EXECUTE STOLEN ORIGINAL BYTES =====
             // Run the original instructions BEFORE the conditional consumed-exit
@@ -342,10 +409,11 @@ namespace KotorPatcher {
             const int OFFSET_EAX    = 32;  // [EBX+32] = EAX
 
             // Original stack data (parameters, etc.) is at:
-            // [EBX + savedStateSize]
+            // [EBX + savedStateSize + kFpAreaSize]
+            // The FXSAVE area sits between the pushed state and the game's own stack.
             // The hook site is reached by a JMP, not a CALL, so there is no return
             // address in between
-            const int STACK_OFFSET_TO_ORIGINAL_DATA = savedStateSize;
+            const int STACK_OFFSET_TO_ORIGINAL_DATA = savedStateSize + kFpAreaSize;
 
             std::string source = param.source;
 

--- a/src/KotorPatcher/src/core/wrapper_x86.cpp
+++ b/src/KotorPatcher/src/core/wrapper_x86.cpp
@@ -284,8 +284,12 @@ namespace KotorPatcher {
                 }
             }
 
-            // Flush instruction cache
-            Platform::FlushICache(wrapperMem, static_cast<size_t>(code - wrapperMem));
+            // The stub was written through a writable mapping, so it only becomes
+            // code once it is sealed. ProtectExec flushes the instruction cache.
+            if (!Platform::ProtectExec(wrapperMem, estimatedSize)) {
+                Platform::Log("[Wrapper] Failed to make the wrapper executable\n");
+                return nullptr;
+            }
 
             char debugMsg[256];
             snprintf(debugMsg, sizeof(debugMsg), "[Wrapper] Generated DETOUR wrapper at 0x%08X (%d bytes)\n",

--- a/src/KotorPatcher/src/core/wrapper_x86.cpp
+++ b/src/KotorPatcher/src/core/wrapper_x86.cpp
@@ -516,11 +516,15 @@ namespace KotorPatcher {
 
         // ===== Factory Function =====
 
-        // Global instance
-        static WrapperGenerator_x86 g_wrapperGenerator;
-
+        // Constructed on first call, not at load time. The entry point runs from a
+        // module initializer, and a generator defined at file scope is only built by
+        // an initializer of its own: whichever the linker ordered first wins, and
+        // calling through the object before its constructor has run reads a null
+        // vtable pointer. The Linux build survived that by the order its objects
+        // happened to be listed in.
         WrapperGeneratorBase* GetWrapperGenerator() {
-            return &g_wrapperGenerator;
+            static WrapperGenerator_x86 generator;
+            return &generator;
         }
 
     } // namespace Wrappers

--- a/src/KotorPatcher/src/core/wrapper_x86_64.cpp
+++ b/src/KotorPatcher/src/core/wrapper_x86_64.cpp
@@ -1,0 +1,477 @@
+#include "wrapper_x86_64.h"
+#include "patcher.h"
+#include "platform.h"
+#include "trampoline.h"
+
+#include <algorithm>
+#include <cinttypes>
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+namespace KotorPatcher {
+    namespace Wrappers {
+        namespace {
+
+            // Register numbers as they appear in ModRM and REX encodings.
+            enum Reg : int {
+                RAX = 0, RCX = 1, RDX = 2, RBX = 3, RSP = 4, RBP = 5, RSI = 6, RDI = 7,
+                R8 = 8, R9 = 9, R10 = 10, R11 = 11, R12 = 12, R13 = 13, R14 = 14, R15 = 15
+            };
+
+            // Saved in this order, which is what fixes the frame layout below. RSP is
+            // absent: it is implicit in the frame, and writing it back from a saved copy
+            // would desynchronise the stack. The hardware POPAD skipped ESP for the same
+            // reason.
+            constexpr Reg kSavedGprs[] = { RAX, RCX, RDX, RBX, RBP, RSI, RDI,
+                                           R8, R9, R10, R11, R12, R13, R14, R15 };
+            constexpr int kSavedGprCount = static_cast<int>(sizeof(kSavedGprs) / sizeof(kSavedGprs[0]));
+
+            // System V AMD64 argument registers, in order.
+            constexpr Reg kIntArgRegs[] = { RDI, RSI, RDX, RCX, R8, R9 };
+            constexpr int kMaxIntArgs = static_cast<int>(sizeof(kIntArgRegs) / sizeof(kIntArgRegs[0]));
+
+            // Floating-point arguments go in XMM0..XMM7, a separate sequence from the
+            // integer registers: a hook taking (int, float, int) uses RDI, XMM0, RSI.
+            constexpr int kMaxSseArgs = 8;
+
+            // The 128 bytes below RSP that a System V leaf function may use as scratch
+            // without adjusting RSP. The hooked instruction can be inside such a function,
+            // so the wrapper steps over the red zone before touching the stack at all.
+            constexpr int kRedZoneSize = 128;
+
+            constexpr int kFlagsSize = 8;
+            constexpr int kGprAreaSize = kSavedGprCount * 8;                 // 0x78
+
+            // FXSAVE writes 512 bytes and requires a 16-byte aligned destination.
+            // Nothing is known about the game's RSP, so the area carries 15 bytes of
+            // slack and the aligned address inside it is computed once there is a
+            // scratch register to compute it with.
+            constexpr int kFpSaveSize = 512;
+            constexpr int kFpAreaOffset = kFlagsSize + kGprAreaSize;         // 0x80
+            constexpr int kFpAreaSize = kFpSaveSize + 16;
+
+            // Frame, measured from the anchor the wrapper keeps in RBX:
+            //
+            //   [RBX + 0x000]            RFLAGS
+            //   [RBX + 0x008 .. 0x07F]   the saved GPRs, last pushed nearest the anchor
+            //   [RBX + 0x080 .. 0x28F]   the FXSAVE area, plus its alignment slack
+            //   [RBX + 0x290 .. 0x30F]   the red zone, stepped over and left alone
+            //   [RBX + 0x310]            the game's RSP at the hook site
+            constexpr int kFrameSize = kFpAreaOffset + kFpAreaSize + kRedZoneSize;
+
+            // Everything is saved even when the config asks for no restore, so that a
+            // parameter sourced from a register always has a value to read. The
+            // preserve flags then decide only what is written back.
+            constexpr int SavedGprOffset(int index) {
+                return kFlagsSize + (kSavedGprCount - 1 - index) * 8;
+            }
+
+            struct RegName { Reg reg; const char* wide; const char* narrow; };
+
+            // Both spellings name the same physical register. A macOS hook adapted from a
+            // Windows one keeps saying "eax", and silently ignoring that would break the
+            // consumed-exit contract, which asks the author to exclude eax from restore.
+            constexpr RegName kRegNames[] = {
+                { RAX, "rax", "eax" }, { RCX, "rcx", "ecx" }, { RDX, "rdx", "edx" },
+                { RBX, "rbx", "ebx" }, { RSP, "rsp", "esp" }, { RBP, "rbp", "ebp" },
+                { RSI, "rsi", "esi" }, { RDI, "rdi", "edi" },
+                { R8, "r8", "r8d" }, { R9, "r9", "r9d" }, { R10, "r10", "r10d" },
+                { R11, "r11", "r11d" }, { R12, "r12", "r12d" }, { R13, "r13", "r13d" },
+                { R14, "r14", "r14d" }, { R15, "r15", "r15d" }
+            };
+
+            bool LookUpRegister(const std::string& name, Reg& outReg) {
+                for (const auto& entry : kRegNames) {
+                    if (name == entry.wide || name == entry.narrow) {
+                        outReg = entry.reg;
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            // Emits into a fixed buffer and refuses to run past the end, so a bad size
+            // estimate shows up as a failed hook rather than a corrupted heap.
+            class Emitter {
+            public:
+                Emitter(uint8_t* buffer, std::size_t capacity)
+                    : m_begin(buffer), m_cursor(buffer), m_end(buffer + capacity) {}
+
+                void Byte(uint8_t value) {
+                    if (m_cursor >= m_end) { m_overflowed = true; return; }
+                    *m_cursor++ = value;
+                }
+
+                void Bytes(const uint8_t* bytes, std::size_t count) {
+                    for (std::size_t i = 0; i < count; ++i) Byte(bytes[i]);
+                }
+
+                void Dword(uint32_t value) {
+                    for (int i = 0; i < 4; ++i) Byte(static_cast<uint8_t>(value >> (i * 8)));
+                }
+
+                bool Overflowed() const { return m_overflowed; }
+                uint8_t* Cursor() const { return m_cursor; }
+                std::size_t Written() const { return static_cast<std::size_t>(m_cursor - m_begin); }
+
+            private:
+                uint8_t* m_begin;
+                uint8_t* m_cursor;
+                uint8_t* m_end;
+                bool m_overflowed = false;
+            };
+
+            // REX prefix, omitted when it would carry no information. W selects a 64-bit
+            // operand; R and B extend the ModRM reg and rm fields to reach R8..R15.
+            void Rex(Emitter& e, bool wide, int regField, int rmField) {
+                uint8_t rex = 0x40;
+                if (wide) rex |= 0x08;
+                if (regField >= 8) rex |= 0x04;
+                if (rmField >= 8) rex |= 0x01;
+                if (rex != 0x40) e.Byte(rex);
+            }
+
+            void PushReg(Emitter& e, int reg) {
+                Rex(e, false, 0, reg);
+                e.Byte(static_cast<uint8_t>(0x50 | (reg & 7)));
+            }
+
+            void PopReg(Emitter& e, int reg) {
+                Rex(e, false, 0, reg);
+                e.Byte(static_cast<uint8_t>(0x58 | (reg & 7)));
+            }
+
+            // `op` reg64, [base + disp32]. Only valid for a base that needs no SIB byte,
+            // which the callers satisfy by always using RBX.
+            void MemOp(Emitter& e, uint8_t op, int reg, int base, int32_t disp) {
+                Rex(e, true, reg, base);
+                e.Byte(op);
+                e.Byte(static_cast<uint8_t>(0x80 | ((reg & 7) << 3) | (base & 7)));
+                e.Dword(static_cast<uint32_t>(disp));
+            }
+
+            void MovFromMem(Emitter& e, int dst, int base, int32_t disp) { MemOp(e, 0x8B, dst, base, disp); }
+            void LeaFromMem(Emitter& e, int dst, int base, int32_t disp) { MemOp(e, 0x8D, dst, base, disp); }
+
+            // LEA RSP, [RSP + disp32]. Deliberately LEA and not ADD/SUB: it leaves the
+            // flags alone, which matters everywhere this is used outside the saved region.
+            void AdjustRsp(Emitter& e, int32_t disp) {
+                e.Byte(0x48); e.Byte(0x8D); e.Byte(0xA4); e.Byte(0x24);
+                e.Dword(static_cast<uint32_t>(disp));
+            }
+
+            // Point RAX at the aligned address inside the FP area, then FXSAVE64 or
+            // FXRSTOR64 through it. ADD and AND write flags, so both callers run this
+            // while the flags are already saved.
+            //
+            // RAX is borrowed and given back. On the way out it still holds the
+            // handler's return value, which the consumed-exit test is about to read and
+            // which the caller was told to exclude from restore precisely so it would
+            // survive this far.
+            void FpSaveArea(Emitter& e, uint8_t modrmReg) {
+                e.Byte(0x50);                                             // PUSH RAX
+                LeaFromMem(e, RAX, RBX, kFpAreaOffset);
+                e.Byte(0x48); e.Byte(0x83); e.Byte(0xC0); e.Byte(0x0F);  // ADD RAX, 15
+                e.Byte(0x48); e.Byte(0x83); e.Byte(0xE0); e.Byte(0xF0);  // AND RAX, -16
+                e.Byte(0x48); e.Byte(0x0F); e.Byte(0xAE);                // REX.W 0F AE /r
+                e.Byte(modrmReg);                                         // [RAX]
+                e.Byte(0x58);                                             // POP RAX
+            }
+
+            void SaveFpState(Emitter& e)    { FpSaveArea(e, 0x00); }  // FXSAVE64  /0
+            void RestoreFpState(Emitter& e) { FpSaveArea(e, 0x08); }  // FXRSTOR64 /1
+
+            // MOVD xmm, r32: moves the raw bits, which is what a float argument in the
+            // low half of an SSE register is.
+            void MovdToXmm(Emitter& e, int xmm, int gpr) {
+                e.Byte(0x66);
+                Rex(e, false, xmm, gpr);
+                e.Byte(0x0F); e.Byte(0x6E);
+                e.Byte(static_cast<uint8_t>(0xC0 | ((xmm & 7) << 3) | (gpr & 7)));
+            }
+
+        } // namespace
+
+        namespace {
+
+            int SavedGprIndex(Reg reg) {
+                for (int i = 0; i < kSavedGprCount; ++i) {
+                    if (kSavedGprs[i] == reg) return i;
+                }
+                return -1;
+            }
+
+            // Excluding either spelling excludes the register.
+            bool ShouldRestore(const WrapperConfig& config, Reg reg) {
+                for (const auto& entry : kRegNames) {
+                    if (entry.reg == reg) {
+                        return config.ShouldRestoreRegister(entry.wide) &&
+                               config.ShouldRestoreRegister(entry.narrow);
+                    }
+                }
+                return true;
+            }
+
+            void EmitRel32(Emitter& e, uint8_t opcode, uintptr_t target, bool& outReachable) {
+                e.Byte(opcode);
+                int32_t rel = 0;
+                outReachable = Trampoline::ComputeRel32(
+                    reinterpret_cast<uintptr_t>(e.Cursor()) - 1, target, rel);
+                e.Dword(static_cast<uint32_t>(rel));
+            }
+
+            // Places one argument in the register the System V convention gives it.
+            bool LoadArgument(Emitter& e, const ParameterInfo& param,
+                              int& intArgIndex, int& sseArgIndex) {
+                std::string source = param.source;
+                std::transform(source.begin(), source.end(), source.begin(),
+                               [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+
+                const bool wantsSse = param.type == ParameterType::FLOAT;
+                if (wantsSse ? sseArgIndex >= kMaxSseArgs : intArgIndex >= kMaxIntArgs) {
+                    Platform::Log("[Wrapper] Too many arguments for the register convention\n");
+                    return false;
+                }
+
+                Reg sourceReg = RAX;
+                if (LookUpRegister(source, sourceReg)) {
+                    int index = SavedGprIndex(sourceReg);
+                    if (index < 0) {
+                        // RSP is the one register with no saved copy. A hook wanting the
+                        // game's stack pointer asks for "rsp+0", which is that address.
+                        Platform::Log(("[Wrapper] No saved copy of " + source +
+                                       "; use rsp+0 for the stack pointer\n").c_str());
+                        return false;
+                    }
+                    if (wantsSse) {
+                        MovFromMem(e, RAX, RBX, SavedGprOffset(index));
+                        MovdToXmm(e, sseArgIndex++, RAX);
+                    } else {
+                        MovFromMem(e, kIntArgRegs[intArgIndex++], RBX, SavedGprOffset(index));
+                    }
+                    return true;
+                }
+
+                // "rsp+8", and "esp+8" from a hook adapted off the Windows one. Like the
+                // x86 generator, this passes the address of that slot rather than what
+                // is in it.
+                const bool stackSource = source.size() > 4 &&
+                    (source.compare(0, 3, "rsp") == 0 || source.compare(0, 3, "esp") == 0) &&
+                    (source[3] == '+' || source[3] == '-');
+                if (stackSource) {
+                    if (wantsSse) {
+                        Platform::Log("[Wrapper] A stack source yields an address, not a float\n");
+                        return false;
+                    }
+                    int userOffset = 0;
+                    try {
+                        userOffset = std::stoi(source.substr(3));
+                    } catch (...) {
+                        Platform::Log(("[Wrapper] Invalid stack offset: " + source + "\n").c_str());
+                        return false;
+                    }
+                    LeaFromMem(e, kIntArgRegs[intArgIndex++], RBX, kFrameSize + userOffset);
+                    return true;
+                }
+
+                Platform::Log(("[Wrapper] Unsupported parameter source: " + source + "\n").c_str());
+                return false;
+            }
+
+        } // namespace
+
+        WrapperGenerator_x86_64::~WrapperGenerator_x86_64() {
+            FreeAllWrappers();
+        }
+
+        void WrapperGenerator_x86_64::FreeAllWrappers() {
+            for (const auto& wrapper : m_allocatedWrappers) {
+                Platform::FreeExec(wrapper.address, wrapper.size);
+            }
+            m_allocatedWrappers.clear();
+        }
+
+        void* WrapperGenerator_x86_64::GenerateWrapper(const WrapperConfig& config) {
+            return GenerateDetourWrapper(config);
+        }
+
+        void* WrapperGenerator_x86_64::GenerateDetourWrapper(const WrapperConfig& config) {
+            // An exact upper bound on what the emitter below can produce, term by term,
+            // so the emitter's own bounds check is a backstop and not the design.
+            const std::size_t capacity =
+                8 + 8                                 // step over the red zone, open the FP area
+                + kSavedGprCount * 2                  // push the GPRs
+                + 1 + 3                               // PUSHFQ, MOV RBX, RSP
+                + 21                                  // address the FP area and FXSAVE64
+                + config.parameters.size() * 12       // worst case for one argument
+                + 2 + 4 + 5                           // MOV AL, AND RSP, CALL
+                + 3 + 8                               // MOV RSP, RBX and the flags slot
+                + 21                                  // address the FP area and FXRSTOR64
+                + kSavedGprCount * 8                  // pop or step past each GPR
+                + 8                                   // close the frame
+                + config.originalBytes.size()
+                + 36                                  // the consumed-exit branch
+                + 5;                                  // the jump back
+
+            // The hook site jumps here and the wrapper jumps back, so the stub has to
+            // land within a relative jump of the code it is hooking.
+            auto* mem = static_cast<uint8_t*>(Platform::AllocExec(capacity, config.hookAddress));
+            if (!mem) {
+                Platform::Log("[Wrapper] Failed to allocate wrapper memory\n");
+                return nullptr;
+            }
+            m_allocatedWrappers.push_back({ mem, capacity });
+
+            Emitter e(mem, capacity);
+
+            // ===== PROLOGUE =====
+            // The red zone first: the hooked instruction can sit inside a leaf function
+            // that is using the 128 bytes below RSP, and every push from here down would
+            // land on top of it.
+            AdjustRsp(e, -kRedZoneSize);
+            AdjustRsp(e, -kFpAreaSize);
+            for (int i = 0; i < kSavedGprCount; ++i) {
+                PushReg(e, kSavedGprs[i]);
+            }
+            e.Byte(0x9C);                                       // PUSHFQ
+            e.Byte(0x48); e.Byte(0x89); e.Byte(0xE3);           // MOV RBX, RSP
+
+            // The floating-point state goes next, now that RAX is free to address it.
+            // Everything FXSAVE covers is caller-saved, so the patch function may
+            // destroy all of it: XMM0..XMM15 hold every float the game is working with,
+            // and MXCSR, the x87 stack and the x87 control word travel with them.
+            SaveFpState(e);
+
+            // ===== ARGUMENTS =====
+            int intArgIndex = 0;
+            int sseArgIndex = 0;
+            for (const auto& param : config.parameters) {
+                if (!LoadArgument(e, param, intArgIndex, sseArgIndex)) {
+                    return nullptr;
+                }
+            }
+            // AL holds the number of vector registers used, which a variadic callee reads
+            // and a normal one ignores.
+            e.Byte(0xB0); e.Byte(static_cast<uint8_t>(sseArgIndex));
+
+            // ===== CALL =====
+            // The convention wants RSP 16-byte aligned at the call itself, and nothing
+            // says what it was at an arbitrary hook site. AND writes flags, which is
+            // harmless here because they are already saved.
+            e.Byte(0x48); e.Byte(0x83); e.Byte(0xE4); e.Byte(0xF0);   // AND RSP, -16
+
+            bool reachable = false;
+            EmitRel32(e, 0xE8, reinterpret_cast<uintptr_t>(config.patchFunction), reachable);
+            if (!reachable) {
+                Platform::Log("[Wrapper] Patch function is out of rel32 range of the wrapper\n");
+                return nullptr;
+            }
+
+            // ===== EPILOGUE =====
+            e.Byte(0x48); e.Byte(0x89); e.Byte(0xDC);           // MOV RSP, RBX
+
+            // Ahead of the flags, because addressing the area writes them, and ahead of
+            // the pops, because it needs RAX.
+            if (config.preserveRegisters) {
+                RestoreFpState(e);
+            }
+
+            if (config.preserveFlags) {
+                e.Byte(0x9D);                                   // POPFQ
+            } else {
+                AdjustRsp(e, kFlagsSize);
+            }
+
+            // RBX is always restored: the wrapper took it as its anchor, so the patch
+            // function never had a say in its value, and skipping it would hand the
+            // game one of our stack addresses instead.
+            for (int i = kSavedGprCount - 1; i >= 0; --i) {
+                if (kSavedGprs[i] == RBX || ShouldRestore(config, kSavedGprs[i])) {
+                    PopReg(e, kSavedGprs[i]);
+                } else {
+                    // LEA rather than ADD, so stepping over a register the patch wanted
+                    // to keep does not disturb the flags just restored above.
+                    AdjustRsp(e, 8);
+                }
+            }
+
+            AdjustRsp(e, kFpAreaSize + kRedZoneSize);
+
+            // ===== STOLEN BYTES =====
+            // Run before the consumed-exit test so both paths leave the same state, as
+            // if the cut had executed in place. See the header on RIP-relative operands.
+            if (!config.skipOriginalBytes) {
+                if (config.originalBytes.empty()) {
+                    Platform::Log("[Wrapper] ERROR: No original bytes provided for DETOUR hook\n");
+                    return nullptr;
+                }
+                e.Bytes(config.originalBytes.data(), config.originalBytes.size());
+            }
+
+            // ===== CONSUMED-EVENT EXIT =====
+            // TEST overwrites the flags the stolen bytes just set, which a Jcc at the
+            // resume point may be about to read, so the test is wrapped in a save and
+            // restore of its own. That save steps over the red zone again, because by
+            // now RSP is the game's once more.
+            if (config.consumedExitAddress != 0) {
+                constexpr uint8_t kConsumedBranchSize = 1 + 8 + 5;  // POPFQ, LEA, JMP rel32
+                AdjustRsp(e, -kRedZoneSize);
+                e.Byte(0x9C);                                   // PUSHFQ
+                e.Byte(0x85); e.Byte(0xC0);                     // TEST EAX, EAX
+                e.Byte(0x74); e.Byte(kConsumedBranchSize);      // JZ to the fall-through
+                e.Byte(0x9D);                                   // POPFQ
+                AdjustRsp(e, kRedZoneSize);
+                EmitRel32(e, 0xE9, config.consumedExitAddress, reachable);
+                if (!reachable) {
+                    Platform::Log("[Wrapper] consumed_exit_address is out of rel32 range\n");
+                    return nullptr;
+                }
+                e.Byte(0x9D);                                   // POPFQ
+                AdjustRsp(e, kRedZoneSize);
+            }
+
+            // ===== RESUME =====
+            const uintptr_t resumeAddress = config.hookAddress + config.originalBytes.size();
+            EmitRel32(e, 0xE9, resumeAddress, reachable);
+            if (!reachable) {
+                Platform::Log("[Wrapper] Resume point is out of rel32 range of the wrapper\n");
+                return nullptr;
+            }
+
+            if (e.Overflowed()) {
+                Platform::Log("[Wrapper] Wrapper exceeded its allocation\n");
+                return nullptr;
+            }
+
+            if (!Platform::ProtectExec(mem, capacity)) {
+                Platform::Log("[Wrapper] Failed to make the wrapper executable\n");
+                return nullptr;
+            }
+
+            char debugMsg[192];
+            snprintf(debugMsg, sizeof(debugMsg),
+                "[Wrapper] Generated DETOUR wrapper at 0x%08" PRIXPTR " (%zu bytes)\n",
+                reinterpret_cast<uintptr_t>(mem), e.Written());
+            Platform::Log(debugMsg);
+
+            return mem;
+        }
+
+        // ===== Factory Function =====
+
+        // One generator is linked per build, the same way one platform backend is, so
+        // this definition and the x86 one are never present together.
+        // Constructed on first call, not at load time. The entry point runs from a
+        // module initializer, and a generator defined at file scope is only built by
+        // an initializer of its own: whichever the linker ordered first wins, and
+        // calling through the object before its constructor has run reads a null
+        // vtable pointer. The Linux build survived that by the order its objects
+        // happened to be listed in.
+        WrapperGeneratorBase* GetWrapperGenerator() {
+            static WrapperGenerator_x86_64 generator;
+            return &generator;
+        }
+
+    } // namespace Wrappers
+} // namespace KotorPatcher

--- a/src/KotorPatcher/src/platform_posix.cpp
+++ b/src/KotorPatcher/src/platform_posix.cpp
@@ -106,7 +106,13 @@ namespace Platform {
         auto* page = reinterpret_cast<void*>(start);
         std::size_t span = end - start;
 
-        if (mprotect(page, span, PROT_READ | PROT_WRITE | PROT_EXEC) != 0) {
+        // Writable and executable at once is asked for first, because it leaves the
+        // page runnable throughout: the deferred-apply path patches while the game is
+        // already running on other threads. Apple Silicon refuses that combination,
+        // and these games are x86_64-only so they always run there under Rosetta, so
+        // dropping execute for the duration of the write is the fallback.
+        if (mprotect(page, span, PROT_READ | PROT_WRITE | PROT_EXEC) != 0 &&
+            mprotect(page, span, PROT_READ | PROT_WRITE) != 0) {
             return false;
         }
         std::memcpy(dest, src, len);

--- a/src/KotorPatcher/src/platform_posix.cpp
+++ b/src/KotorPatcher/src/platform_posix.cpp
@@ -17,6 +17,7 @@
 #include <string>
 
 #include "platform.h"
+#include "stub_placement.h"
 
 namespace KotorPatcher {
 namespace Platform {
@@ -50,10 +51,37 @@ namespace Platform {
         }
     }
 
-    void* AllocExec(std::size_t size) {
-        void* mem = mmap(nullptr, size, PROT_READ | PROT_WRITE,
-                         MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-        return mem == MAP_FAILED ? nullptr : mem;
+    // Mapped writable, never writable+executable: macOS refuses that mapping, and
+    // these games are x86_64-only, so every Apple Silicon Mac runs them under
+    // Rosetta and would hit the refusal. ProtectExec flips the block to executable.
+    void* AllocExec(std::size_t size, std::uintptr_t nearAddress) {
+        auto map = [size](void* hint) -> void* {
+            void* mem = mmap(hint, size, PROT_READ | PROT_WRITE,
+                             MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+            return mem == MAP_FAILED ? nullptr : mem;
+        };
+
+        if (StubPlacement::kEveryAddressReaches || nearAddress == 0) {
+            return map(nullptr);
+        }
+
+        for (std::size_t attempt = 0; attempt < StubPlacement::kSearchAttempts; ++attempt) {
+            std::uintptr_t hint = 0;
+            if (!StubPlacement::NextCandidate(nearAddress, attempt, hint)) break;
+
+            // Without MAP_FIXED the hint is only a suggestion, and an occupied one is
+            // answered with a mapping wherever the kernel pleased. MAP_FIXED is not an
+            // option: it would silently unmap whatever already lives there.
+            void* mem = map(reinterpret_cast<void*>(hint));
+            if (!mem) continue;
+            if (StubPlacement::NearEnough(nearAddress, reinterpret_cast<std::uintptr_t>(mem), size)) {
+                return mem;
+            }
+            munmap(mem, size);
+        }
+
+        Platform::Log("[KotorPatcher] No free memory within a relative jump of the game\n");
+        return nullptr;
     }
 
     bool ProtectExec(void* addr, std::size_t size) {

--- a/src/KotorPatcher/src/platform_posix.cpp
+++ b/src/KotorPatcher/src/platform_posix.cpp
@@ -51,9 +51,17 @@ namespace Platform {
     }
 
     void* AllocExec(std::size_t size) {
-        void* mem = mmap(nullptr, size, PROT_READ | PROT_WRITE | PROT_EXEC,
+        void* mem = mmap(nullptr, size, PROT_READ | PROT_WRITE,
                          MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
         return mem == MAP_FAILED ? nullptr : mem;
+    }
+
+    bool ProtectExec(void* addr, std::size_t size) {
+        if (mprotect(addr, size, PROT_READ | PROT_EXEC) != 0) {
+            return false;
+        }
+        FlushICache(addr, size);
+        return true;
     }
 
     void FreeExec(void* addr, std::size_t size) {

--- a/src/KotorPatcher/src/platform_win32.cpp
+++ b/src/KotorPatcher/src/platform_win32.cpp
@@ -15,7 +15,16 @@ namespace Platform {
     }
 
     void* AllocExec(std::size_t size) {
-        return VirtualAlloc(nullptr, size, MEM_COMMIT | MEM_RESERVE, PAGE_EXECUTE_READWRITE);
+        return VirtualAlloc(nullptr, size, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+    }
+
+    bool ProtectExec(void* addr, std::size_t size) {
+        DWORD oldProtect = 0;
+        if (!VirtualProtect(addr, size, PAGE_EXECUTE_READ, &oldProtect)) {
+            return false;
+        }
+        FlushInstructionCache(GetCurrentProcess(), addr, size);
+        return true;
     }
 
     void FreeExec(void* addr, std::size_t /*size*/) {

--- a/src/KotorPatcher/src/platform_win32.cpp
+++ b/src/KotorPatcher/src/platform_win32.cpp
@@ -6,6 +6,7 @@
 #include <string>
 
 #include "platform.h"
+#include "stub_placement.h"
 
 namespace KotorPatcher {
 namespace Platform {
@@ -14,8 +15,25 @@ namespace Platform {
         OutputDebugStringA(message);
     }
 
-    void* AllocExec(std::size_t size) {
-        return VirtualAlloc(nullptr, size, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+    void* AllocExec(std::size_t size, std::uintptr_t nearAddress) {
+        if (StubPlacement::kEveryAddressReaches || nearAddress == 0) {
+            return VirtualAlloc(nullptr, size, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+        }
+
+        for (std::size_t attempt = 0; attempt < StubPlacement::kSearchAttempts; ++attempt) {
+            std::uintptr_t hint = 0;
+            if (!StubPlacement::NextCandidate(nearAddress, attempt, hint)) break;
+
+            // Unlike mmap, VirtualAlloc honours the base address or fails, so a
+            // conflict just means trying the next candidate. It rounds the base down
+            // to the allocation granularity, which stays inside the window.
+            void* mem = VirtualAlloc(reinterpret_cast<void*>(hint), size,
+                                     MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+            if (mem) return mem;
+        }
+
+        Log("[KotorPatcher] No free memory within a relative jump of the game\n");
+        return nullptr;
     }
 
     bool ProtectExec(void* addr, std::size_t size) {

--- a/src/KotorPatcher/src/stub_placement.h
+++ b/src/KotorPatcher/src/stub_placement.h
@@ -1,0 +1,62 @@
+#pragma once
+#include <cstddef>
+#include <cstdint>
+
+// Where to put a generated stub so the game can jump to it.
+//
+// A hook site is redirected with a 5-byte relative jump, which reaches a signed
+// 32-bit displacement. On the 32-bit targets that is the whole address space, so a
+// stub can go anywhere. On the macOS x86_64 target the game image sits at
+// 0x100000000 while the allocator is free to answer from anywhere in a 47-bit
+// space, so a stub has to be placed deliberately.
+//
+// This is policy shared by both platform backends, which differ only in how they
+// ask the OS for a specific address. It is a conservative approximation:
+// Trampoline::ComputeRel32 remains the authority on whether a jump reaches.
+
+namespace KotorPatcher {
+namespace StubPlacement {
+
+    // Search a little inside the true rel32 limit so the far end of the block is
+    // reachable too, and so the jump back out of it still fits.
+    constexpr std::uintptr_t kRel32Reach = 0x7FF00000;
+
+    // Every 32-bit address is within a rel32 of every other, because the
+    // displacement wraps in the same width the CPU computes in. Searching there
+    // could only fail where a plain allocation would have succeeded.
+    constexpr bool kEveryAddressReaches = sizeof(void*) == 4;
+
+    // Candidates are walked outward from the hint in both directions. A megabyte
+    // covers the whole window in a bounded number of tries, and the space just past
+    // a game image is normally free, so the first or second try lands.
+    constexpr std::uintptr_t kSearchStep = 0x100000;
+    constexpr std::size_t kSearchAttempts = 2 * (kRel32Reach / kSearchStep);
+
+    // Whether a block of `size` bytes at `candidate` is close enough to `nearAddress`
+    // for a relative jump in either direction.
+    inline bool NearEnough(std::uintptr_t nearAddress, std::uintptr_t candidate,
+                           std::size_t size) {
+        std::uintptr_t lo = candidate < nearAddress ? candidate : nearAddress;
+        std::uintptr_t hi = candidate < nearAddress ? nearAddress : candidate + size;
+        return hi - lo <= kRel32Reach;
+    }
+
+    // Address to try on `attempt`, alternating above and below `nearAddress`.
+    // Returns false once the walk would leave the window or run off the bottom of
+    // the address space, which ends the search.
+    inline bool NextCandidate(std::uintptr_t nearAddress, std::size_t attempt,
+                              std::uintptr_t& outHint) {
+        std::uintptr_t offset = (attempt / 2 + 1) * kSearchStep;
+        if (offset > kRel32Reach) return false;
+
+        if (attempt % 2 == 0) {
+            outHint = nearAddress + offset;
+        } else {
+            if (offset > nearAddress) return false;
+            outHint = nearAddress - offset;
+        }
+        return true;
+    }
+
+} // namespace StubPlacement
+} // namespace KotorPatcher

--- a/src/KotorPatcher/tests/README.md
+++ b/src/KotorPatcher/tests/README.md
@@ -1,0 +1,50 @@
+# Code generator tests
+
+Run them with `make test` from `src/KotorPatcher`.
+
+The engine writes machine code while the game is running: the trampoline works
+out jump displacements, the platform backend hands out memory to put stubs in,
+and the two DETOUR wrapper generators emit the code that calls a patch
+function. These tests cover that code.
+
+They are not unit tests in the usual sense. Each one builds a fake hook site in
+a page of stub memory, points it at a wrapper the generator has just produced,
+jumps into it with a known value in every register, and checks what comes out
+the other end. Running the bytes is the only way to tell whether they are
+right. Reading them back only proves they are the bytes we meant to write, not
+that those bytes do what we wanted.
+
+## Why they run on the host
+
+What a generator emits depends on the instruction set, not on the operating
+system. An x86_64 wrapper built for macOS is byte for byte the one built here,
+so running it on Linux tests that build too. That is worth having, because
+testing the macOS engine any other way means a virtual machine with a copy of
+the game in it.
+
+You need an x86 host that can build 32-bit binaries (`glibc-devel.i686` on
+Fedora, `gcc-multilib` on Debian and Ubuntu). There is nothing here to run on
+other architectures.
+
+## Layout
+
+- `any_*` is built at both widths, once against each wrapper generator.
+- `t32_*` and `t64_*` are built against the generator for their instruction
+  set.
+
+A test is a program that prints its checks and exits non-zero if any of them
+failed. `check.h` is the whole framework.
+
+## What is covered
+
+- Jump displacements, including the wrap-around cases at 32 bits that a naive
+  range check gets wrong, and the exact boundary at 64 bits.
+- Stub memory: writable, then sealed, then callable, and placed close enough to
+  a given address that a relative jump reaches it.
+- Wrappers: passing arguments, reading a parameter out of a register or off the
+  stack, stack alignment at the call, the saved state surviving a patch
+  function that destroys everything it is allowed to, the stolen bytes running,
+  flags surviving to the resume point, the red zone, excluded registers, and
+  both consumed-exit paths.
+- Floating point: x87, MMX, SSE and MXCSR surviving a patch function that calls
+  `fninit` and zeroes the XMM registers.

--- a/src/KotorPatcher/tests/any_rel32.cpp
+++ b/src/KotorPatcher/tests/any_rel32.cpp
@@ -1,0 +1,36 @@
+#include "trampoline.h"
+#include <cstdio>
+
+#include "check.h"
+#include <cstdint>
+#include <cstddef>
+using KotorPatcher::Trampoline::ComputeRel32;
+static void expect(const char* name, uintptr_t from, uintptr_t to, bool wantOk) {
+    int32_t rel = 0;
+    bool ok = ComputeRel32(from, to, rel);
+    bool lands = ok && (from + 5 + static_cast<uintptr_t>(static_cast<intptr_t>(rel))) == to;
+    bool pass = (ok == wantOk) && (!ok || lands);
+    if (!pass) ++kptest::g_failures;
+    printf("  %-34s ok=%d rel=%+d lands=%d  %s\n", name, ok, rel, lands, pass ? "PASS" : "FAIL");
+}
+int main() {
+    printf("uintptr_t = %zu bits\n", sizeof(uintptr_t) * 8);
+    expect("forward near", 0x401000, 0x402000, true);
+    expect("backward near", 0x402000, 0x401000, true);
+    if (sizeof(uintptr_t) == 4) {
+        expect("32-bit wrap high->low", 0xFFFF0000u, 0x00001000u, true);
+        expect("32-bit wrap low->high", 0x00001000u, 0xFFFF0000u, true);
+    }
+#if UINTPTR_MAX > 0xFFFFFFFFu
+    else {
+        expect("mac image internal", 0x100000000ull, 0x1004EB6C2ull, true);
+        expect("mmap block far above image", 0x100000000ull, 0x7F1234567000ull, false);
+        expect("mmap block far below image", 0x7F1234567000ull, 0x100000000ull, false);
+        expect("exactly +INT32_MAX", 0x100000000ull, 0x100000000ull + 5 + 0x7FFFFFFFull, true);
+        expect("one past +INT32_MAX", 0x100000000ull, 0x100000000ull + 5 + 0x80000000ull, false);
+        expect("exactly -INT32_MIN", 0x800000000ull, 0x800000000ull + 5 - 0x80000000ull, true);
+        expect("one past -INT32_MIN", 0x800000000ull, 0x800000000ull + 5 - 0x80000001ull, false);
+    }
+#endif
+    return kptest::Report();
+}

--- a/src/KotorPatcher/tests/any_stub_memory.cpp
+++ b/src/KotorPatcher/tests/any_stub_memory.cpp
@@ -1,0 +1,31 @@
+// Stub memory is handed out writable and only becomes executable once sealed,
+// so a stub has to be written before ProtectExec and callable after it.
+#include <cstdio>
+#include <cstring>
+
+#include "check.h"
+#include "platform.h"
+
+using namespace KotorPatcher;
+
+int main() {
+    std::printf("  stub memory, %zu-bit\n", sizeof(void*) * 8);
+
+    // mov eax, 42 ; ret. The same encoding on x86 and x86_64.
+    const unsigned char code[] = { 0xB8, 0x2A, 0x00, 0x00, 0x00, 0xC3 };
+
+    void* mem = Platform::AllocExec(64, 0);
+    kptest::Check("AllocExec returned a block", mem != nullptr);
+    if (!mem) return kptest::Report();
+
+    std::memcpy(mem, code, sizeof(code));          // writable here
+    kptest::Check("ProtectExec sealed it", Platform::ProtectExec(mem, 64));
+
+    int got = reinterpret_cast<int (*)()>(mem)();  // executable here
+    char detail[32];
+    std::snprintf(detail, sizeof(detail), "(returned %d)", got);
+    kptest::Check("the sealed stub runs", got == 42, detail);
+
+    Platform::FreeExec(mem, 64);
+    return kptest::Report();
+}

--- a/src/KotorPatcher/tests/any_stub_placement.cpp
+++ b/src/KotorPatcher/tests/any_stub_placement.cpp
@@ -1,0 +1,36 @@
+#include "platform.h"
+#include "trampoline.h"
+#include <cstdio>
+
+#include "check.h"
+#include <cstring>
+#include <ctime>
+using namespace KotorPatcher;
+static void check(const char* name, uintptr_t game) {
+    clock_t t0 = clock();
+    void* mem = Platform::AllocExec(4096, game);
+    double ms = 1000.0 * (clock() - t0) / CLOCKS_PER_SEC;
+    if (!mem) { printf("  %-30s ALLOC FAILED (%.1f ms)\n", name, ms); ++kptest::g_failures; return; }
+    uintptr_t p = reinterpret_cast<uintptr_t>(mem);
+    int32_t there = 0, back = 0;
+    bool ok = Trampoline::ComputeRel32(game, p, there) &&
+              Trampoline::ComputeRel32(p + 4091, game, back);
+    long long d = (long long)p - (long long)game;
+    printf("  %-30s block=%#llx delta=%+lld reaches=%d %.1fms %s\n", name,
+           (unsigned long long)p, d, ok, ms, ok ? "PASS" : "FAIL");
+    if (!ok) ++kptest::g_failures;
+    Platform::FreeExec(mem, 4096);
+}
+int main() {
+    printf("uintptr_t = %zu bits\n", sizeof(uintptr_t) * 8);
+#if UINTPTR_MAX > 0xFFFFFFFFu
+    // Addresses a macOS game image and a typical mmap region would sit at.
+    check("mac image base 0x100000000", 0x100000000ull);
+    check("high address 0x7F0000000000", 0x7F0000000000ull);
+#endif
+    check("this function", reinterpret_cast<uintptr_t>(&main));
+    void* any = Platform::AllocExec(4096, 0);
+    printf("  %-30s %s\n", "unconstrained (hint 0)", any ? "PASS" : "FAIL");
+    if (!any) ++kptest::g_failures; else Platform::FreeExec(any, 4096);
+    return kptest::Report();
+}

--- a/src/KotorPatcher/tests/check.h
+++ b/src/KotorPatcher/tests/check.h
@@ -1,0 +1,21 @@
+#pragma once
+#include <cstdio>
+
+// Shared reporting for the code-generator tests. Each test is a small program
+// that returns non-zero when something failed, so `make test` can just run them.
+
+namespace kptest {
+
+    inline int g_failures = 0;
+
+    inline void Check(const char* what, bool passed, const char* detail = "") {
+        if (!passed) ++g_failures;
+        std::printf("    %-44s %s %s\n", what, passed ? "PASS" : "FAIL", detail);
+    }
+
+    inline int Report() {
+        std::printf(g_failures ? "  FAILURES: %d\n" : "  all pass\n", g_failures);
+        return g_failures != 0;
+    }
+
+} // namespace kptest

--- a/src/KotorPatcher/tests/t32_consumed_exit.cpp
+++ b/src/KotorPatcher/tests/t32_consumed_exit.cpp
@@ -1,0 +1,81 @@
+// i386 consumed-exit: the handler's return value in EAX has to survive the whole
+// epilogue, including the FXRSTOR that borrows EAX to address its save area.
+#include "wrapper_x86.h"
+#include "patcher.h"
+#include "platform.h"
+#include "trampoline.h"
+#include <cstdio>
+
+#include "check.h"
+#include <cstring>
+#include <cstdint>
+using namespace KotorPatcher;
+extern "C" {
+    void* g_hookEntry; int g_landed; int g_ret; uint32_t g_flags;
+    void kick(void); void land_resume(void); void land_consumed(void);
+    int probe(void) { return g_ret; }
+}
+asm(R"(
+.text
+.globl kick
+kick:
+    pushl %ebx
+    pushl %esi
+    pushl %edi
+    pushl %ebp
+    movl $1, %eax
+    cmpl %eax, %eax                 /* ZF=1, must still hold at the landing pad */
+    jmp  *g_hookEntry
+.globl land_resume
+land_resume:
+    movl $0, g_landed
+    jmp  common
+.globl land_consumed
+land_consumed:
+    movl $1, g_landed
+common:
+    pushfl
+    popl g_flags
+    popl %ebp
+    popl %edi
+    popl %esi
+    popl %ebx
+    ret
+)");
+
+static bool build(Wrappers::WrapperGenerator_x86& gen) {
+    static const uint8_t stolen[] = { 0x90,0x90,0x90,0x90,0x90 };
+    auto* site = static_cast<uint8_t*>(Platform::AllocExec(4096, (uintptr_t)&probe));
+    if (!site) return false;
+    g_hookEntry = site;
+    Wrappers::WrapperConfig c;
+    c.patchFunction = (void*)&probe;
+    c.hookAddress = (uintptr_t)site;
+    c.originalBytes.assign(stolen, stolen + sizeof(stolen));
+    c.excludeFromRestore = { "eax" };
+    c.consumedExitAddress = (uintptr_t)&land_consumed;
+    void* w = gen.GenerateWrapper(c);
+    if (!w) return false;
+    int32_t rel = 0;
+    Trampoline::ComputeRel32((uintptr_t)site, (uintptr_t)w, rel);
+    site[0] = 0xE9; std::memcpy(site+1, &rel, 4);
+    uint8_t* r = site + sizeof(stolen);
+    Trampoline::ComputeRel32((uintptr_t)r, (uintptr_t)&land_resume, rel);
+    r[0] = 0xE9; std::memcpy(r+1, &rel, 4);
+    return Platform::ProtectExec(site, 4096);
+}
+
+int main() {
+    Wrappers::WrapperGenerator_x86 gen;
+    g_ret = 1; g_landed = -1;
+    if (!build(gen)) { printf("build failed\n"); return 1; }
+    kick();
+    kptest::Check("non-zero return takes the consumed exit", g_landed == 1);
+
+    g_ret = 0; g_landed = -1;
+    if (!build(gen)) { printf("build failed\n"); return 1; }
+    kick();
+    kptest::Check("zero return falls through to resume", g_landed == 0);
+    kptest::Check("ZF from before the hook survives", (g_flags & 0x40) != 0);
+    return kptest::Report();
+}

--- a/src/KotorPatcher/tests/t32_fp_state.cpp
+++ b/src/KotorPatcher/tests/t32_fp_state.cpp
@@ -1,0 +1,100 @@
+// The patch function destroys the whole floating-point state. FXSAVE/FXRSTOR in
+// the wrapper must put it back before the game resumes.
+#include "wrapper_x86.h"
+#include "patcher.h"
+#include "platform.h"
+#include "trampoline.h"
+#include <cstdio>
+
+#include "check.h"
+#include <cstring>
+#include <cstdint>
+using namespace KotorPatcher;
+
+extern "C" {
+    void*    g_hookEntry;
+    double   g_seedX87[2], g_gotX87[2];
+    uint64_t g_seedXmm[2], g_gotXmm[2];
+    uint32_t g_seedMxcsr, g_gotMxcsr;
+    void kick(void); void capture(void);
+    int probe(void) {
+        // Everything a System V callee may legally destroy.
+        asm volatile(
+            "fninit\n\t"                 // wipe the x87 stack and control word
+            "fldz\n\t"                   // leave something wrong in ST0
+            "pxor %%xmm0, %%xmm0\n\t"
+            "pxor %%xmm3, %%xmm3\n\t"
+            ::: "xmm0", "xmm3");
+        return 0;
+    }
+}
+
+asm(R"(
+.text
+.globl kick
+kick:
+    pushl %ebx
+    pushl %esi
+    pushl %edi
+    pushl %ebp
+    fldl g_seedX87+8
+    fldl g_seedX87+0
+    movq g_seedXmm+0, %xmm0
+    movq g_seedXmm+8, %xmm3
+    stmxcsr g_seedMxcsr
+    jmp  *g_hookEntry
+
+.globl capture
+capture:
+    fstpl g_gotX87+0
+    fstpl g_gotX87+8
+    movq %xmm0, g_gotXmm+0
+    movq %xmm3, g_gotXmm+8
+    stmxcsr g_gotMxcsr
+    popl %ebp
+    popl %edi
+    popl %esi
+    popl %ebx
+    ret
+)");
+
+
+int main() {
+    g_seedX87[0] = 3.14159265358979; g_seedX87[1] = 2.71828182845905;
+    g_seedXmm[0] = 0x5EED000000000001ull; g_seedXmm[1] = 0x5EED000000000009ull;
+
+    const uint8_t stolen[] = { 0x90,0x90,0x90,0x90,0x90 };
+    auto* site = static_cast<uint8_t*>(Platform::AllocExec(4096, (uintptr_t)&probe));
+    g_hookEntry = site;
+
+    Wrappers::WrapperGenerator_x86 gen;
+    Wrappers::WrapperConfig c;
+    c.patchFunction = (void*)&probe;
+    c.hookAddress = (uintptr_t)site;
+    c.originalBytes.assign(stolen, stolen + sizeof(stolen));
+
+    void* w = gen.GenerateWrapper(c);
+    if (!w) { printf("generation failed\n"); return 1; }
+    int32_t rel = 0;
+    Trampoline::ComputeRel32((uintptr_t)site, (uintptr_t)w, rel);
+    site[0] = 0xE9; std::memcpy(site+1, &rel, 4);
+    uint8_t* resume = site + sizeof(stolen);
+    Trampoline::ComputeRel32((uintptr_t)resume, (uintptr_t)&capture, rel);
+    resume[0] = 0xE9; std::memcpy(resume+1, &rel, 4);
+    Platform::ProtectExec(site, 4096);
+
+    kick();
+
+    char d[80];
+    snprintf(d, sizeof(d), "(%.14f)", g_gotX87[0]);
+    kptest::Check("x87 ST0 survived fninit", g_gotX87[0] == g_seedX87[0], d);
+    snprintf(d, sizeof(d), "(%.14f)", g_gotX87[1]);
+    kptest::Check("x87 ST1 survived fninit", g_gotX87[1] == g_seedX87[1], d);
+    snprintf(d, sizeof(d), "(%#llx)", (unsigned long long)g_gotXmm[0]);
+    kptest::Check("xmm0 restored", g_gotXmm[0] == g_seedXmm[0], d);
+    snprintf(d, sizeof(d), "(%#llx)", (unsigned long long)g_gotXmm[1]);
+    kptest::Check("xmm3 restored", g_gotXmm[1] == g_seedXmm[1], d);
+    snprintf(d, sizeof(d), "(%#x vs %#x)", g_gotMxcsr, g_seedMxcsr);
+    kptest::Check("MXCSR restored", g_gotMxcsr == g_seedMxcsr, d);
+    return kptest::Report();
+}

--- a/src/KotorPatcher/tests/t32_no_preserve.cpp
+++ b/src/KotorPatcher/tests/t32_no_preserve.cpp
@@ -1,0 +1,88 @@
+// preserveRegisters = false: the patch's register changes are meant to stick, but
+// the wrapper's own anchor must not leak into the game.
+#include "wrapper_x86.h"
+#include "patcher.h"
+#include "platform.h"
+#include "trampoline.h"
+#include <cstdio>
+
+#include "check.h"
+#include <cstring>
+#include <cstdint>
+using namespace KotorPatcher;
+
+extern "C" {
+    void* g_hookEntry;
+    uint32_t g_gameEbx, g_arg0, g_captured[8];
+    void kick(void); void capture(void); void probe(void);
+}
+asm(R"(
+.text
+.globl probe
+probe:
+    movl 4(%esp), %eax
+    movl %eax, g_arg0
+    movl $0xC0FFEE00, %ecx      /* the patch's own change, which must survive */
+    xorl %eax, %eax
+    ret
+
+.globl kick
+kick:
+    pushl %ebx
+    pushl %esi
+    pushl %edi
+    pushl %ebp
+    movl $0xAA000000, %eax
+    movl $0xAA000001, %ecx
+    movl $0xAA000003, %ebx
+    movl %ebx, g_gameEbx
+    jmp  *g_hookEntry
+
+.globl capture
+capture:
+    movl %eax, g_captured+0
+    movl %ecx, g_captured+4
+    movl %ebx, g_captured+12
+    popl %ebp
+    popl %edi
+    popl %esi
+    popl %ebx
+    ret
+)");
+
+
+int main() {
+    const uint8_t stolen[] = { 0x90,0x90,0x90,0x90,0x90 };
+    auto* site = static_cast<uint8_t*>(Platform::AllocExec(4096, (uintptr_t)&probe));
+    g_hookEntry = site;
+
+    Wrappers::WrapperGenerator_x86 gen;
+    Wrappers::WrapperConfig c;
+    c.patchFunction = (void*)&probe;
+    c.hookAddress = (uintptr_t)site;
+    c.originalBytes.assign(stolen, stolen + sizeof(stolen));
+    c.preserveRegisters = false;          // the case under test
+    c.preserveFlags = false;
+    c.parameters = { { "eax", ParameterType::UINT } };   // needs the saved copy to exist
+
+    void* w = gen.GenerateWrapper(c);
+    if (!w) { printf("generation failed\n"); return 1; }
+    int32_t rel = 0;
+    Trampoline::ComputeRel32((uintptr_t)site, (uintptr_t)w, rel);
+    site[0] = 0xE9; std::memcpy(site+1, &rel, 4);
+    uint8_t* resume = site + sizeof(stolen);
+    Trampoline::ComputeRel32((uintptr_t)resume, (uintptr_t)&capture, rel);
+    resume[0] = 0xE9; std::memcpy(resume+1, &rel, 4);
+    Platform::ProtectExec(site, 4096);
+
+    kick();
+
+    char d[64];
+    snprintf(d, sizeof(d), "(got %#x)", g_arg0);
+    kptest::Check("register parameter still readable without preserve", g_arg0 == 0xAA000000, d);
+    snprintf(d, sizeof(d), "(got %#x want %#x)", g_captured[3], g_gameEbx);
+    kptest::Check("ebx is the game's, not the wrapper's anchor", g_captured[3] == g_gameEbx, d);
+    snprintf(d, sizeof(d), "(got %#x)", g_captured[1]);
+    kptest::Check("ecx keeps the patch's value, as asked", g_captured[1] == 0xC0FFEE00, d);
+    return kptest::Report();
+}

--- a/src/KotorPatcher/tests/t32_wrapper.cpp
+++ b/src/KotorPatcher/tests/t32_wrapper.cpp
@@ -1,0 +1,114 @@
+// Runs a wrapper the i386 generator produced: checks the stack is 16-byte aligned
+// at the call, and that both a register source and a stack source still arrive
+// correctly now that extraction is anchored on EBX.
+#include "wrapper_x86.h"
+#include "patcher.h"
+#include "platform.h"
+#include "trampoline.h"
+#include <cstdio>
+
+#include "check.h"
+#include <cstring>
+#include <cstdint>
+using namespace KotorPatcher;
+
+extern "C" {
+    void*    g_hookEntry;
+    uint32_t g_gameEsp, g_espAtEntry, g_arg0, g_arg1;
+    uint32_t g_captured[8];
+    void kick(void);
+    void capture(void);
+    void probe(void);
+}
+
+asm(R"(
+.text
+.globl probe
+probe:
+    movl %esp, g_espAtEntry      /* includes the return address the CALL pushed */
+    movl 4(%esp), %eax
+    movl %eax, g_arg0
+    movl 8(%esp), %eax
+    movl %eax, g_arg1
+    xorl %eax, %eax
+    ret
+
+.globl kick
+kick:
+    pushl %ebx
+    pushl %esi
+    pushl %edi
+    pushl %ebp
+    movl %esp, g_gameEsp
+    movl $0xAA000000, %eax
+    movl $0xAA000001, %ecx
+    movl $0xAA000002, %edx
+    movl $0xAA000003, %ebx
+    movl $0xAA000005, %ebp
+    movl $0xAA000006, %esi
+    movl $0xAA000007, %edi
+    jmp  *g_hookEntry
+
+.globl capture
+capture:
+    movl %eax, g_captured+0
+    movl %ecx, g_captured+4
+    movl %edx, g_captured+8
+    movl %ebx, g_captured+12
+    movl %ebp, g_captured+20
+    movl %esi, g_captured+24
+    movl %edi, g_captured+28
+    popl %ebp
+    popl %edi
+    popl %esi
+    popl %ebx
+    ret
+)");
+
+
+int main() {
+    const uint8_t stolen[] = { 0x90, 0x90, 0x90, 0x90, 0x90 };
+    auto* site = static_cast<uint8_t*>(
+        Platform::AllocExec(4096, reinterpret_cast<uintptr_t>(&probe)));
+    if (!site) { printf("alloc failed\n"); return 1; }
+    g_hookEntry = site;
+
+    Wrappers::WrapperGenerator_x86 gen;
+    Wrappers::WrapperConfig config;
+    config.patchFunction = reinterpret_cast<void*>(&probe);
+    config.hookAddress = reinterpret_cast<uintptr_t>(site);
+    config.originalBytes.assign(stolen, stolen + sizeof(stolen));
+    config.parameters = {
+        { "eax",   ParameterType::UINT },      // register source
+        { "esp+4", ParameterType::POINTER },   // stack source: the path re-anchored on EBX
+    };
+
+    void* wrapper = gen.GenerateWrapper(config);
+    if (!wrapper) { printf("generation failed\n"); return 1; }
+
+    int32_t rel = 0;
+    Trampoline::ComputeRel32((uintptr_t)site, (uintptr_t)wrapper, rel);
+    site[0] = 0xE9; std::memcpy(site + 1, &rel, 4);
+    uint8_t* resume = site + sizeof(stolen);
+    Trampoline::ComputeRel32((uintptr_t)resume, (uintptr_t)&capture, rel);
+    resume[0] = 0xE9; std::memcpy(resume + 1, &rel, 4);
+    Platform::ProtectExec(site, 4096);
+
+    kick();
+
+    char d[80];
+    // The CALL pushed a return address, so an aligned call leaves esp+4 aligned here.
+    snprintf(d, sizeof(d), "(esp at entry %#x)", g_espAtEntry);
+    kptest::Check("stack 16-byte aligned at the call", ((g_espAtEntry + 4) % 16) == 0, d);
+    kptest::Check("register source eax arrived", g_arg0 == 0xAA000000);
+    snprintf(d, sizeof(d), "(got %#x want %#x)", g_arg1, g_gameEsp + 4);
+    kptest::Check("stack source esp+4 arrived", g_arg1 == g_gameEsp + 4, d);
+
+    const char* n[8] = {"eax","ecx","edx","ebx","","ebp","esi","edi"};
+    for (int i = 0; i < 8; ++i) {
+        if (i == 4) continue;
+        char lbl[48]; snprintf(lbl, sizeof(lbl), "%s restored at the resume point", n[i]);
+        kptest::Check(lbl, g_captured[i] == (0xAA000000u + i));
+    }
+    return kptest::Report();
+}

--- a/src/KotorPatcher/tests/t64_edge_cases.cpp
+++ b/src/KotorPatcher/tests/t64_edge_cases.cpp
@@ -1,0 +1,164 @@
+#include "wrapper_x86_64.h"
+#include "patcher.h"
+#include "platform.h"
+#include "trampoline.h"
+#include <cstdio>
+
+#include "check.h"
+#include <cstring>
+#include <cstdint>
+using namespace KotorPatcher;
+
+extern "C" {
+    void*    g_hookEntry;
+    uint64_t g_gameRsp;          // RSP at the hook site
+    uint64_t g_redZone[4];       // what the game left below RSP
+    uint64_t g_redZoneAfter[4];
+    uint64_t g_rax, g_flags;
+    int      g_landedConsumed;
+    uint64_t g_stackArg;
+    int      g_probeReturn;
+    uint64_t g_seenArg0;
+    void kick(void);
+    void land_resume(void);
+    void land_consumed(void);
+
+    int probe(uint64_t a) {
+        g_seenArg0 = a;
+        return g_probeReturn;
+    }
+}
+
+// The game seeds its red zone, records RSP, then falls into the hook. Whichever
+// landing pad the wrapper picks records what came back and unwinds.
+asm(R"(
+.text
+.globl kick
+kick:
+    push %rbx
+    push %rbp
+    push %r12
+    push %r13
+    push %r14
+    push %r15
+    movq %rsp, g_gameRsp(%rip)
+    /* Seed four slots of the red zone, the 128 bytes below RSP a leaf function
+       may use without adjusting RSP. */
+    lea  g_redZone(%rip), %rax
+    movq   0(%rax), %rdx
+    movq %rdx,   -8(%rsp)
+    movq   8(%rax), %rdx
+    movq %rdx,  -32(%rsp)
+    movq  16(%rax), %rdx
+    movq %rdx,  -64(%rsp)
+    movq  24(%rax), %rdx
+    movq %rdx, -128(%rsp)
+    movq $0x1234567800000000, %rax
+    cmpq %rax, %rax                 /* ZF=1, which must still be set at the landing pad */
+    jmp  *g_hookEntry(%rip)
+
+.globl land_resume
+land_resume:
+    movl $0, g_landedConsumed(%rip)
+    jmp  common_land
+.globl land_consumed
+land_consumed:
+    movl $1, g_landedConsumed(%rip)
+common_land:
+    /* Snapshot before anything that writes below RSP or touches the flags.
+       Only MOV is used here, and MOV sets no flags. */
+    movq %rax, g_rax(%rip)
+    lea  g_redZoneAfter(%rip), %rax
+    movq   -8(%rsp), %rdx
+    movq %rdx,   0(%rax)
+    movq  -32(%rsp), %rdx
+    movq %rdx,   8(%rax)
+    movq  -64(%rsp), %rdx
+    movq %rdx,  16(%rax)
+    movq -128(%rsp), %rdx
+    movq %rdx,  24(%rax)
+    pushfq
+    popq g_flags(%rip)
+    pop  %r15
+    pop  %r14
+    pop  %r13
+    pop  %r12
+    pop  %rbp
+    pop  %rbx
+    ret
+)");
+
+
+// Builds a hook site that jumps into a freshly generated wrapper, with the resume
+// point wired to land_resume.
+static bool build(Wrappers::WrapperGenerator_x86_64& gen, Wrappers::WrapperConfig config,
+                  const uint8_t* stolen, std::size_t stolenLen) {
+    auto* site = static_cast<uint8_t*>(
+        Platform::AllocExec(4096, reinterpret_cast<uintptr_t>(&probe)));
+    if (!site) return false;
+    g_hookEntry = site;
+    config.hookAddress = reinterpret_cast<uintptr_t>(site);
+    config.originalBytes.assign(stolen, stolen + stolenLen);
+    config.patchFunction = reinterpret_cast<void*>(&probe);
+
+    void* wrapper = gen.GenerateWrapper(config);
+    if (!wrapper) return false;
+
+    int32_t rel = 0;
+    if (!Trampoline::ComputeRel32((uintptr_t)site, (uintptr_t)wrapper, rel)) return false;
+    site[0] = 0xE9; std::memcpy(site + 1, &rel, 4);
+    std::memset(site + 5, 0x90, stolenLen - 5);
+    uint8_t* resume = site + stolenLen;
+    if (!Trampoline::ComputeRel32((uintptr_t)resume, (uintptr_t)&land_resume, rel)) return false;
+    resume[0] = 0xE9; std::memcpy(resume + 1, &rel, 4);
+    return Platform::ProtectExec(site, 4096);
+}
+
+int main() {
+    for (int i = 0; i < 4; ++i) g_redZone[i] = 0xDEC0DE0000ull + i;
+    const uint8_t stolen[] = { 0x90, 0x90, 0x90, 0x90, 0x90 };   // five NOPs: no side effect
+    Wrappers::WrapperGenerator_x86_64 gen;
+
+    printf("  red zone and flags survive a hook\n");
+    {
+        Wrappers::WrapperConfig c;
+        c.parameters = { { "rsp+0", ParameterType::POINTER } };
+        g_probeReturn = 0;
+        if (!build(gen, c, stolen, sizeof(stolen))) { printf("   build failed\n"); return 1; }
+        std::memset(g_redZoneAfter, 0, sizeof(g_redZoneAfter));
+        kick();
+        kptest::Check("red zone untouched", std::memcmp(g_redZone, g_redZoneAfter, sizeof(g_redZone)) == 0);
+        kptest::Check("ZF from before the hook survives", (g_flags & 0x40) != 0);
+        char d[64]; snprintf(d, sizeof(d), "(arg %#lx vs rsp %#lx)", g_seenArg0, g_gameRsp);
+        kptest::Check("rsp+0 gives the game's stack pointer", g_seenArg0 == g_gameRsp, d);
+    }
+
+    printf("  consumed-exit taken when the handler returns non-zero\n");
+    {
+        Wrappers::WrapperConfig c;
+        c.excludeFromRestore = { "eax" };      // the Windows spelling, on purpose
+        c.consumedExitAddress = reinterpret_cast<uintptr_t>(&land_consumed);
+        g_probeReturn = 1;
+        if (!build(gen, c, stolen, sizeof(stolen))) { printf("   build failed\n"); return 1; }
+        g_landedConsumed = -1;
+        kick();
+        kptest::Check("landed on the consumed target", g_landedConsumed == 1);
+        kptest::Check("excluded eax kept the handler's value", g_rax == 1);
+    }
+
+    printf("  fall-through when the handler returns zero\n");
+    {
+        Wrappers::WrapperConfig c;
+        c.excludeFromRestore = { "eax" };
+        c.consumedExitAddress = reinterpret_cast<uintptr_t>(&land_consumed);
+        g_probeReturn = 0;
+        if (!build(gen, c, stolen, sizeof(stolen))) { printf("   build failed\n"); return 1; }
+        g_landedConsumed = -1;
+        std::memset(g_redZoneAfter, 0, sizeof(g_redZoneAfter));
+        kick();
+        kptest::Check("landed on the resume point", g_landedConsumed == 0);
+        kptest::Check("red zone untouched by the exit test",
+           std::memcmp(g_redZone, g_redZoneAfter, sizeof(g_redZone)) == 0);
+    }
+    return kptest::Report();
+}

--- a/src/KotorPatcher/tests/t64_fp_state.cpp
+++ b/src/KotorPatcher/tests/t64_fp_state.cpp
@@ -1,0 +1,104 @@
+// The patch function destroys the whole floating-point state. FXSAVE/FXRSTOR in
+// the wrapper must put it back before the game resumes.
+#include "wrapper_x86_64.h"
+#include "patcher.h"
+#include "platform.h"
+#include "trampoline.h"
+#include <cstdio>
+
+#include "check.h"
+#include <cstring>
+#include <cstdint>
+using namespace KotorPatcher;
+
+extern "C" {
+    void*    g_hookEntry;
+    double   g_seedX87[2], g_gotX87[2];
+    uint64_t g_seedXmm[2], g_gotXmm[2];
+    uint32_t g_seedMxcsr, g_gotMxcsr;
+    void kick(void); void capture(void);
+    int probe(void) {
+        // Everything a System V callee may legally destroy.
+        asm volatile(
+            "fninit\n\t"                 // wipe the x87 stack and control word
+            "fldz\n\t"                   // leave something wrong in ST0
+            "pxor %%xmm0, %%xmm0\n\t"
+            "pxor %%xmm9, %%xmm9\n\t"
+            ::: "xmm0", "xmm9");
+        return 0;
+    }
+}
+
+asm(R"(
+.text
+.globl kick
+kick:
+    push %rbx
+    push %rbp
+    push %r12
+    push %r13
+    push %r14
+    push %r15
+    fldl g_seedX87+8(%rip)          /* ST1 after the next push */
+    fldl g_seedX87+0(%rip)          /* ST0 */
+    movq g_seedXmm+0(%rip), %xmm0
+    movq g_seedXmm+8(%rip), %xmm9
+    stmxcsr g_seedMxcsr(%rip)
+    jmp  *g_hookEntry(%rip)
+
+.globl capture
+capture:
+    fstpl g_gotX87+0(%rip)          /* pops ST0 */
+    fstpl g_gotX87+8(%rip)          /* pops what was ST1 */
+    movq %xmm0, g_gotXmm+0(%rip)
+    movq %xmm9, g_gotXmm+8(%rip)
+    stmxcsr g_gotMxcsr(%rip)
+    pop  %r15
+    pop  %r14
+    pop  %r13
+    pop  %r12
+    pop  %rbp
+    pop  %rbx
+    ret
+)");
+
+
+int main() {
+    g_seedX87[0] = 3.14159265358979; g_seedX87[1] = 2.71828182845905;
+    g_seedXmm[0] = 0x5EED000000000001ull; g_seedXmm[1] = 0x5EED000000000009ull;
+
+    const uint8_t stolen[] = { 0x90,0x90,0x90,0x90,0x90 };
+    auto* site = static_cast<uint8_t*>(Platform::AllocExec(4096, (uintptr_t)&probe));
+    g_hookEntry = site;
+
+    Wrappers::WrapperGenerator_x86_64 gen;
+    Wrappers::WrapperConfig c;
+    c.patchFunction = (void*)&probe;
+    c.hookAddress = (uintptr_t)site;
+    c.originalBytes.assign(stolen, stolen + sizeof(stolen));
+
+    void* w = gen.GenerateWrapper(c);
+    if (!w) { printf("generation failed\n"); return 1; }
+    int32_t rel = 0;
+    Trampoline::ComputeRel32((uintptr_t)site, (uintptr_t)w, rel);
+    site[0] = 0xE9; std::memcpy(site+1, &rel, 4);
+    uint8_t* resume = site + sizeof(stolen);
+    Trampoline::ComputeRel32((uintptr_t)resume, (uintptr_t)&capture, rel);
+    resume[0] = 0xE9; std::memcpy(resume+1, &rel, 4);
+    Platform::ProtectExec(site, 4096);
+
+    kick();
+
+    char d[80];
+    snprintf(d, sizeof(d), "(%.14f)", g_gotX87[0]);
+    kptest::Check("x87 ST0 survived fninit", g_gotX87[0] == g_seedX87[0], d);
+    snprintf(d, sizeof(d), "(%.14f)", g_gotX87[1]);
+    kptest::Check("x87 ST1 survived fninit", g_gotX87[1] == g_seedX87[1], d);
+    snprintf(d, sizeof(d), "(%#llx)", (unsigned long long)g_gotXmm[0]);
+    kptest::Check("xmm0 restored", g_gotXmm[0] == g_seedXmm[0], d);
+    snprintf(d, sizeof(d), "(%#llx)", (unsigned long long)g_gotXmm[1]);
+    kptest::Check("xmm9 restored", g_gotXmm[1] == g_seedXmm[1], d);
+    snprintf(d, sizeof(d), "(%#x vs %#x)", g_gotMxcsr, g_seedMxcsr);
+    kptest::Check("MXCSR restored", g_gotMxcsr == g_seedMxcsr, d);
+    return kptest::Report();
+}

--- a/src/KotorPatcher/tests/t64_wrapper.cpp
+++ b/src/KotorPatcher/tests/t64_wrapper.cpp
@@ -1,0 +1,202 @@
+// Executes a wrapper the x86_64 generator produced, with a synthetic hook site.
+// The generated code is plain x86_64, so it runs here exactly as it would on macOS.
+#include "wrapper_x86_64.h"
+#include "patcher.h"
+#include "platform.h"
+#include "trampoline.h"
+#include <cstdio>
+
+#include "check.h"
+#include <cstring>
+#include <cstdint>
+
+using namespace KotorPatcher;
+
+extern "C" {
+    uint64_t g_seed[16];        // values the "game" holds at the hook site
+    uint64_t g_captured[16];    // what survives to the resume point
+    uint64_t g_capturedFlags;
+    uint64_t g_seedXmm[32];     // 16 x 2 qwords
+    uint64_t g_capturedXmm[32];
+    void*    g_hookEntry;
+    void     kick(void);
+    void     capture(void);
+
+    // The patch function. Records what the wrapper handed it.
+    uint64_t g_arg[3];
+    int g_calls;
+    int probe(uint64_t a, uint64_t b, uint64_t c) {
+        g_arg[0] = a; g_arg[1] = b; g_arg[2] = c;
+        ++g_calls;
+        // Clobber everything a System V callee is allowed to clobber, to prove the
+        // wrapper's save and restore is doing real work.
+        asm volatile(
+            "movq $0xDEADBEEF11111111, %%rcx\n\t"
+            "movq $0xDEADBEEF22222222, %%rdx\n\t"
+            "movq $0xDEADBEEF33333333, %%rsi\n\t"
+            "movq $0xDEADBEEF44444444, %%rdi\n\t"
+            "movq $0xDEADBEEF55555555, %%r8\n\t"
+            "movq $0xDEADBEEF66666666, %%r9\n\t"
+            "movq $0xDEADBEEF77777777, %%r10\n\t"
+            "movq $0xDEADBEEF88888888, %%r11\n\t"
+            "pxor %%xmm0, %%xmm0\n\t"
+            "pxor %%xmm3, %%xmm3\n\t"
+            "pxor %%xmm7, %%xmm7\n\t"
+            "pxor %%xmm15, %%xmm15\n\t"
+            ::: "rcx","rdx","rsi","rdi","r8","r9","r10","r11",
+                "xmm0","xmm3","xmm7","xmm15");
+        return 0;   // "not consumed"
+    }
+}
+
+// The game side. kick() seeds every register, jumps to the hook site, and the
+// wrapper's resume point lands on capture(), which records what came back.
+asm(R"(
+.text
+.globl kick
+kick:
+    push %rbx
+    push %rbp
+    push %r12
+    push %r13
+    push %r14
+    push %r15
+    lea  g_seedXmm(%rip), %rax
+    movups   0(%rax), %xmm0
+    movups  16(%rax), %xmm1
+    movups 112(%rax), %xmm7
+    movups 240(%rax), %xmm15
+    lea  g_seed(%rip), %rax
+    movq  8(%rax), %rcx
+    movq 16(%rax), %rdx
+    movq 24(%rax), %rbx
+    movq 40(%rax), %rbp
+    movq 48(%rax), %rsi
+    movq 56(%rax), %rdi
+    movq 64(%rax), %r8
+    movq 72(%rax), %r9
+    movq 80(%rax), %r10
+    movq 88(%rax), %r11
+    movq 96(%rax), %r12
+    movq 104(%rax), %r13
+    movq 112(%rax), %r14
+    movq 120(%rax), %r15
+    movq  0(%rax), %rax
+    jmp  *g_hookEntry(%rip)
+
+.globl capture
+capture:
+    pushfq
+    pop  g_capturedFlags(%rip)
+    movq %rax, g_captured+0(%rip)
+    movq %rcx, g_captured+8(%rip)
+    movq %rdx, g_captured+16(%rip)
+    movq %rbx, g_captured+24(%rip)
+    movq %rbp, g_captured+40(%rip)
+    movq %rsi, g_captured+48(%rip)
+    movq %rdi, g_captured+56(%rip)
+    movq %r8,  g_captured+64(%rip)
+    movq %r9,  g_captured+72(%rip)
+    movq %r10, g_captured+80(%rip)
+    movq %r11, g_captured+88(%rip)
+    movq %r12, g_captured+96(%rip)
+    movq %r13, g_captured+104(%rip)
+    movq %r14, g_captured+112(%rip)
+    movq %r15, g_captured+120(%rip)
+    lea  g_capturedXmm(%rip), %rax
+    movups %xmm0,   0(%rax)
+    movups %xmm1,  16(%rax)
+    movups %xmm7, 112(%rax)
+    movups %xmm15,240(%rax)
+    pop  %r15
+    pop  %r14
+    pop  %r13
+    pop  %r12
+    pop  %rbp
+    pop  %rbx
+    ret
+)");
+
+
+static void expect(const char* what, uint64_t got, uint64_t want) {
+    char detail[64];
+    std::snprintf(detail, sizeof(detail), "(%#018lx)", (unsigned long)got);
+    kptest::Check(what, got == want, got == want ? detail : "");
+    if (got != want) std::printf("      got %#018lx want %#018lx\n",
+                                 (unsigned long)got, (unsigned long)want);
+}
+
+int main() {
+    const char* names[16] = {"rax","rcx","rdx","rbx","rsp","rbp","rsi","rdi",
+                             "r8","r9","r10","r11","r12","r13","r14","r15"};
+    for (int i = 0; i < 16; ++i) g_seed[i] = 0xA5A50000ull + i;
+    for (int i = 0; i < 32; ++i) g_seedXmm[i] = 0x5EED0000ull + i;
+
+    // originalBytes: "add rax, 7" then a NOP, so the stolen bytes leave a mark we
+    // can see at the resume point, and the cut is the 5 bytes a JMP needs.
+    const uint8_t stolen[] = { 0x48, 0x83, 0xC0, 0x07, 0x90 };
+
+    // The hook site, placed near the patch function so every rel32 has room.
+    auto* site = static_cast<uint8_t*>(
+        Platform::AllocExec(4096, reinterpret_cast<uintptr_t>(&probe)));
+    if (!site) { printf("could not allocate the hook site\n"); return 1; }
+    g_hookEntry = site;
+
+    Wrappers::WrapperGenerator_x86_64 gen;
+    Wrappers::WrapperConfig config;
+    config.patchFunction = reinterpret_cast<void*>(&probe);
+    config.hookAddress = reinterpret_cast<uintptr_t>(site);
+    config.originalBytes.assign(stolen, stolen + sizeof(stolen));
+    config.parameters = {
+        { "rax", ParameterType::UINT },
+        { "rcx", ParameterType::UINT },
+        { "rsi", ParameterType::POINTER },
+    };
+    config.preserveRegisters = true;
+    config.preserveFlags = true;
+
+    void* wrapper = gen.GenerateWrapper(config);
+    if (!wrapper) { printf("wrapper generation FAILED\n"); return 1; }
+
+    // Stand in for what the patcher would write: jump into the wrapper, then let the
+    // resume point (site + stolen.size()) hand control to capture().
+    int32_t rel = 0;
+    if (!Trampoline::ComputeRel32(reinterpret_cast<uintptr_t>(site),
+                                  reinterpret_cast<uintptr_t>(wrapper), rel)) {
+        printf("wrapper is out of reach of the hook site\n"); return 1;
+    }
+    site[0] = 0xE9; std::memcpy(site + 1, &rel, 4);
+    std::memset(site + 5, 0x90, sizeof(stolen) - 5);
+    uint8_t* resume = site + sizeof(stolen);
+    if (!Trampoline::ComputeRel32(reinterpret_cast<uintptr_t>(resume),
+                                  reinterpret_cast<uintptr_t>(&capture), rel)) {
+        printf("capture is out of reach of the resume point\n"); return 1;
+    }
+    resume[0] = 0xE9; std::memcpy(resume + 1, &rel, 4);
+    if (!Platform::ProtectExec(site, 4096)) { printf("could not seal the hook site\n"); return 1; }
+
+    kick();
+
+    printf("  patch function calls: %d\n", g_calls);
+    if (g_calls != 1) ++kptest::g_failures;
+    printf("  arguments the wrapper passed:\n");
+    expect("arg0 <- rax", g_arg[0], g_seed[0]);
+    expect("arg1 <- rcx", g_arg[1], g_seed[1]);
+    expect("arg2 <- rsi", g_arg[2], g_seed[6]);
+
+    printf("  registers at the resume point:\n");
+    for (int i = 0; i < 16; ++i) {
+        if (i == 4) continue;                       // rsp is not part of the frame
+        uint64_t want = (i == 0) ? g_seed[0] + 7    // the stolen "add rax, 7" ran
+                                 : g_seed[i];
+        char label[32]; snprintf(label, sizeof(label), "%s", names[i]);
+        expect(label, g_captured[i], want);
+    }
+    printf("  SSE registers:\n");
+    const int xmmChecked[] = { 0, 1, 7, 15 };
+    for (int j : xmmChecked) {
+        char label[32]; snprintf(label, sizeof(label), "xmm%d.lo", j);
+        expect(label, g_capturedXmm[j * 2], g_seedXmm[j * 2]);
+    }
+    return kptest::Report();
+}


### PR DESCRIPTION
We only have the ability to write 32-bit x86 wrappers for DETOUR patches. It leans on two instructions, `PUSHAD` and `POPAD`, that do not exist on a 64-bit CPU, and it passes arguments the way 32-bit Windows code expects. So on a 64-bit build of the engine, DETOUR hooks are not broken so much as absent.

This adds a second wrapper writer for 64-bit, sitting beside the old one. The build links whichever matches the architecture, the same way it already picks a platform backend.

Writing the new one kept turning up things wrong with the old one. Four, in code that ships right now on Windows and Linux.

**Floating point was never saved.** The wrapper saved the integer registers and the flags and stopped there. These games do their float work on the x87 stack, which holds eight values, and a patch function doing any floating point of its own pushes onto that same stack. Hook a spot where the game is holding a live number and it quietly gets trampled. No crash, no message, just a wrong value turning up later. Both wrapper writers now bracket the call with `FXSAVE` and `FXRSTOR`, which covers x87, MMX, SSE and MXCSR in one instruction each way.

**The stack was not aligned before the call.** The wrapper called the patch function on whatever alignment the hook site happened to have, which is nothing you can rely on. Compilers disagree about whose job it is to fix that. MSVC and MinGW realign in their own prologue; GCC assumes the caller already did. Since we cannot know what built a given patch DLL, the wrapper now aligns unconditionally and gives every one of them the stronger promise.

**The saved state was skipped when nothing was going to be restored.** With `preserve_registers` off, a parameter that was supposed to come out of a register instead read whatever happened to be sitting on the game's stack, and EBX, which the wrapper uses to find its own frame, was left holding one of our addresses instead of the game's. State is now always saved, and the preserve flags only decide what gets written back.

**The wrapper writer built itself at load time.** It was an object at file scope, so its constructor ran from a module initializer. Our entry point is also a module initializer and calls straight into that object, so whichever one the linker happened to order first decided whether the thing had been constructed yet. The Linux `.so` has only ever worked because of the order its object files are listed in.

The first two can affect a patch someone has installed today. The other two are latent: nothing in `Patches/` turns off `preserve_registers`, and the link order has been lucky.

## The new 64-bit wrapper writer

`wrapper_x86_64.cpp`. The interesting parts:

- It steps over the red zone, the 128 bytes below the stack pointer that a 64-bit leaf function may scribble in without telling anyone. The instruction we hook can be inside such a function, so the wrapper gets out of the way before touching the stack at all.
- It aligns the stack to 16 at the call, same reasoning as above.
- It accepts a register written either way round, so a hook ported from the Windows one that still says `eax` keeps working instead of silently failing to exclude RAX and breaking the consumed-exit contract.

Three smaller changes came along because 64-bit needs them. All three do nothing on a 32-bit target:

- **A relative jump is checked before it is written.** At 32 bits the arithmetic wraps and every address reaches every other, so the right test is whether the offset survives sign extension, not whether it falls inside some range.
- **Stub memory is allocated near the code that will jump to it.** On 64-bit a stub can easily land further away than a 5-byte jump can reach. At 32 bits that cannot happen, so the search is skipped entirely.
- **Addresses are carried as `uintptr_t`.** A config address parses as 64 bits and is narrowed once. One that will not fit is refused rather than truncated into some other, perfectly plausible address in the same image.

## One more change worth calling out

Stub memory used to come back readable, writable and executable all at once, and stay that way. Now it arrives writable, gets filled in, and is sealed as read plus execute before anything jumps to it. Apple Silicon refuses to hand out a page that is writable and executable at the same time, so this was not optional for the Mac work, and it is the better way round on Windows and Linux anyway.

To be clear about what it does not mean: the stub stays readable throughout. The only thing it gives up is being written to, and only once it is finished. Patching the game's own code is a separate path and still asks for all three permissions first, because the deferred-apply path writes while the game is already running on other threads.

## What is not here

The macOS build itself. Nothing links the new file into a shipped artifact yet, which is why the tests are in this PR rather than after it. `make test` is currently the only thing that compiles and runs the 64-bit wrapper writer.

## How I tested it

`make test` from `src/KotorPatcher` builds ten small programs at both widths and runs them. Each assembles a fake hook site, points it at a wrapper the generator has just produced, jumps in with a known value in every register, and checks what came out the far end. Actually running the bytes is the only way to know they are right. Reading them back only proves they are the bytes we meant to write, not that those bytes do what we wanted. It needs an x86 machine that can build 32-bit binaries.

Then in game:

- **KOTOR 1 (GOG 1.03) under Wine**, five patches, 57 hooks between them. 14 DETOUR, 26 SIMPLE and 17 REPLACE, every one applied, nothing failed, game runs.