### PR TITLE
KotorPatcher dylib build support

### DIFF
--- a/src/KotorPatcher/Makefile
+++ b/src/KotorPatcher/Makefile
@@ -1,12 +1,15 @@
 # Build the KotorPatcher engine on Linux hosts.
 #
-# One engine, two artifacts from shared sources:
-#   KotorPatcher.dll  i686 PE, injected into the Windows game (also under Wine)
-#   KotorPatcher.so   i386 ELF, loaded into the Aspyr KOTOR2 Linux build
+# One engine, three artifacts from shared sources:
+#   KotorPatcher.dll    i686 PE, injected into the Windows game (also under Wine)
+#   KotorPatcher.so     i386 ELF, loaded into the Aspyr KOTOR2 Linux build
+#   KotorPatcher.dylib  x86_64 Mach-O, loaded into the Aspyr macOS builds
 #
 # The MSVC KotorPatcher.vcxproj stays the Windows release build; this Makefile is
 # the Linux-side build (contributors, CI, the Wine/Proton DLL, and the Linux .so).
-# KOTOR is 32-bit, so both artifacts are i686/i386.
+# The Windows and Linux games are 32-bit; the Aspyr macOS builds are x86_64,
+# which is why the dylib is the odd one out and why Apple Silicon runs them
+# under Rosetta.
 #
 # sqlite is not linked: the runtime calls no sqlite symbol (only the per-patch
 # DLLs use it, through their own GameAPI build).
@@ -19,6 +22,21 @@
 # default is already posix (Fedora). Override with CXX_WIN=... in the environment.
 CXX_WIN   ?= $(shell command -v i686-w64-mingw32-g++-posix 2>/dev/null || echo i686-w64-mingw32-g++)
 CXX_LINUX := g++
+
+# Building a Mach-O from Linux needs an osxcross toolchain, which supplies the
+# macOS SDK and the ld64 the format requires. It is looked up on PATH and then in
+# the usual install location; on a Mac, set CXX_MAC=clang++ instead. The `dylib`
+# target is deliberately not part of `all`, so a machine without the toolchain
+# still builds the other two.
+CXX_MAC   ?= $(shell command -v o64-clang++ 2>/dev/null || \
+                     ls /usr/local/lib/osxcross/bin/o64-clang++ 2>/dev/null || \
+                     echo o64-clang++)
+
+# Joins the per-architecture slices into the shipped dylib. Present as plain
+# `lipo` both in osxcross and on a Mac.
+LIPO      ?= $(shell command -v lipo 2>/dev/null || \
+                     ls /usr/local/lib/osxcross/bin/lipo 2>/dev/null || \
+                     echo lipo)
 
 BUILD    := build
 INCLUDES := -Iinclude -Iinclude/wrappers -Iexternal
@@ -34,20 +52,72 @@ WIN_LDFLAGS  := -shared -static -lkernel32
 LINUX_CXXFLAGS := $(COMMON) -m32 -fPIC -pthread
 LINUX_LDFLAGS  := -m32 -shared -pthread -ldl
 
-# The Windows DLL and the Linux .so are the same engine; only the entry point
-# (dllmain / soentry) and the platform backend differ.
+# macOS gets its own base rather than COMMON: -s and the -static-libgcc/-stdc++
+# pair are GCC options with no meaning here, and libc++ ships with the OS. The
+# deployment target is the older of the two games' minimums (KOTOR II asks for
+# 10.9.5), so the engine is never the thing that raises the bar. The install name
+# matches what gets written into the game's LC_LOAD_DYLIB, and is the same
+# @executable_path form the game already uses for libBink2Macx64.dylib.
+# -arch is added per slice below, not here.
+MAC_MIN      ?= 10.9
+MAC_CXXFLAGS := -std=c++17 -O2 $(INCLUDES) -mmacosx-version-min=$(MAC_MIN) -fPIC
+MAC_LDFLAGS  := -dynamiclib -mmacosx-version-min=$(MAC_MIN) -Wl,-x \
+                -install_name @executable_path/KotorPatcher.dylib
+
+# Architectures in the shipped dylib. x86_64 is the only one the games need: both
+# Aspyr builds are x86_64, and Apple Silicon runs them under Rosetta, which loads
+# x86_64 slices. Others are a build away only once their code generation exists,
+# so overriding this is not on its own enough:
+#   i386   needs an SDK old enough to ship a 32-bit libc++; MacOSX14 does not,
+#          and the wrapper generator is already there.
+#   arm64  needs a wrapper generator AND an arm64 trampoline, since Trampoline
+#          emits E9/E8 by hand. Only worth doing if Aspyr ship a native build.
+MAC_ARCHS ?= x86_64
+
+# The wrapper generator is chosen by instruction set: the x86 one is built on
+# opcodes that do not exist in long mode.
+MAC_WRAPPER_x86_64 := src/core/wrapper_x86_64.cpp
+MAC_WRAPPER_i386   := src/core/wrapper_x86.cpp
+
+# All three artifacts are the same engine. They differ in the entry point
+# (dllmain / soentry / dylibentry), the platform backend, and the wrapper
+# generator: exactly one of those is linked, chosen by the instruction set, since
+# the x86 one is built on opcodes that do not exist in long mode.
 CORE_SRCS := src/core/config_reader.cpp \
              src/core/patcher.cpp \
-             src/core/trampoline.cpp \
-             src/core/wrapper_x86.cpp
+             src/core/trampoline.cpp
 
-WIN_SRCS   := $(CORE_SRCS) src/platform_win32.cpp src/dllmain.cpp
-LINUX_SRCS := $(CORE_SRCS) src/platform_posix.cpp src/soentry.cpp
+WIN_SRCS   := $(CORE_SRCS) src/core/wrapper_x86.cpp src/platform_win32.cpp src/dllmain.cpp
+LINUX_SRCS := $(CORE_SRCS) src/core/wrapper_x86.cpp src/platform_posix.cpp src/soentry.cpp
+MAC_SRCS   := $(CORE_SRCS) src/platform_posix.cpp src/dylibentry.cpp
 
 # Windows and Linux objects are compiled from overlapping sources with different
 # compilers, so they must not share an object directory.
 WIN_OBJS   := $(patsubst src/%.cpp,$(BUILD)/win/%.o,$(WIN_SRCS))
 LINUX_OBJS := $(patsubst src/%.cpp,$(BUILD)/linux/%.o,$(LINUX_SRCS))
+
+# Refuse an architecture whose code generation is missing, rather than link one
+# whose GetWrapperGenerator resolves to nothing.
+$(foreach arch,$(MAC_ARCHS),$(if $(MAC_WRAPPER_$(arch)),,\
+  $(error No wrapper generator for macOS arch '$(arch)'; set MAC_WRAPPER_$(arch))))
+
+# One object directory and one thin dylib per slice, since the slices are
+# compiled from overlapping sources for different instruction sets.
+define MAC_SLICE_RULES
+MAC_OBJS_$(1) := $$(patsubst src/%.cpp,$$(BUILD)/mac/$(1)/%.o,$$(MAC_SRCS) $$(MAC_WRAPPER_$(1)))
+MAC_THIN_$(1) := $$(BUILD)/mac/KotorPatcher-$(1).dylib
+
+$$(BUILD)/mac/$(1)/%.o: src/%.cpp
+	@mkdir -p $$(dir $$@)
+	$$(CXX_MAC) $$(MAC_CXXFLAGS) -arch $(1) -c $$< -o $$@
+
+$$(MAC_THIN_$(1)): $$(MAC_OBJS_$(1))
+	@mkdir -p $$(dir $$@)
+	$$(CXX_MAC) $$(MAC_CXXFLAGS) -arch $(1) -o $$@ $$^ $$(MAC_LDFLAGS) -arch $(1)
+endef
+$(foreach arch,$(MAC_ARCHS),$(eval $(call MAC_SLICE_RULES,$(arch))))
+
+MAC_THIN := $(foreach arch,$(MAC_ARCHS),$(MAC_THIN_$(arch)))
 
 # Always build to these fixed, space-free in-tree paths. The final destinations
 # (DLL_OUT/SO_OUT) may be absolute paths under a directory containing spaces -- the
@@ -56,22 +126,24 @@ LINUX_OBJS := $(patsubst src/%.cpp,$(BUILD)/linux/%.o,$(LINUX_SRCS))
 # spaced path silently becomes several bogus targets. Build here, then copy to the
 # requested destination in the recipe below, where the shell (not Make) handles the
 # spaces via quoting.
-BUILD_DLL := $(BUILD)/KotorPatcher.dll
-BUILD_SO  := $(BUILD)/KotorPatcher.so
+BUILD_DLL   := $(BUILD)/KotorPatcher.dll
+BUILD_SO    := $(BUILD)/KotorPatcher.so
+BUILD_DYLIB := $(BUILD)/KotorPatcher.dylib
 
 # Optional final destination for each artifact. When set, the dll/so target copies
 # the built binary there (the release scripts use this to drop it into the release
 # tree); when empty, the binary is left at its BUILD_* path. Overridable in the env.
-DLL_OUT ?=
-SO_OUT  ?=
+DLL_OUT   ?=
+SO_OUT    ?=
+DYLIB_OUT ?=
 
-.PHONY: all dll so test clean
+.PHONY: all dll so dylib test clean
 all: dll so
 
 # Host tests for the code generators. Each assembles a hook site, runs a stub the
 # generator produced, and checks what came back, so they need an x86 host with
 # 32-bit support. The emitted bytes do not depend on the OS, so running them here
-# covers the Windows build too.
+# covers the Windows and macOS builds too.
 #
 # tests/any_* are built at both widths; tests/t32_* and tests/t64_* pick the
 # wrapper generator that matches their instruction set.
@@ -111,6 +183,8 @@ dll: $(BUILD_DLL)
 	@if [ -n "$(DLL_OUT)" ] && [ ! "$(DLL_OUT)" -ef "$(BUILD_DLL)" ]; then cp -f "$(BUILD_DLL)" "$(DLL_OUT)"; fi
 so: $(BUILD_SO)
 	@if [ -n "$(SO_OUT)" ] && [ ! "$(SO_OUT)" -ef "$(BUILD_SO)" ]; then cp -f "$(BUILD_SO)" "$(SO_OUT)"; fi
+dylib: $(BUILD_DYLIB)
+	@if [ -n "$(DYLIB_OUT)" ] && [ ! "$(DYLIB_OUT)" -ef "$(BUILD_DYLIB)" ]; then cp -f "$(BUILD_DYLIB)" "$(DYLIB_OUT)"; fi
 
 $(BUILD_DLL): $(WIN_OBJS)
 	@mkdir -p $(dir $@)
@@ -119,6 +193,12 @@ $(BUILD_DLL): $(WIN_OBJS)
 $(BUILD_SO): $(LINUX_OBJS)
 	@mkdir -p $(dir $@)
 	$(CXX_LINUX) $(LINUX_CXXFLAGS) -o $@ $^ $(LINUX_LDFLAGS)
+
+# lipo on a single input still writes a fat container around it, so a one-slice
+# build is copied instead, leaving the artifact exactly as a plain link produced.
+$(BUILD_DYLIB): $(MAC_THIN)
+	@mkdir -p $(dir $@)
+	$(if $(filter 1,$(words $(MAC_THIN))),cp -f $^ $@,$(LIPO) -create $^ -output $@)
 
 $(BUILD)/win/%.o: src/%.cpp
 	@mkdir -p $(dir $@)

--- a/src/KotorPatcher/src/dylibentry.cpp
+++ b/src/KotorPatcher/src/dylibentry.cpp
@@ -1,0 +1,36 @@
+// KotorPatcher.dylib: the macOS entry point for the patcher engine.
+//
+// The Aspyr macOS builds are x86_64 Mach-O, so neither KotorPatcher.dll nor the
+// i386 KotorPatcher.so can load into them. This dylib is named in the game
+// executable's own LC_LOAD_DYLIB list, so dyld maps it at startup, before the
+// game's entry point runs. Whoever launches the game, our code is already inside
+// the process. DYLD_INSERT_LIBRARIES reaches the same place without editing the
+// executable, which is how a build gets tried before it is deployed.
+//
+// The constructor and destructor are the macOS counterparts to dllmain.cpp's
+// DLL_PROCESS_ATTACH/DETACH, and are written exactly as soentry.cpp writes them:
+// clang puts a constructor in __DATA,__mod_init_func, which dyld runs for the
+// same reasons the ELF loader runs an .init_array entry.
+
+#include "patcher.h"
+#include "platform.h"
+
+namespace {
+
+// Runs when dyld maps this library, before the game's main().
+__attribute__((constructor))
+void kpatchInit() {
+    if (!KotorPatcher::InitializePatcher()) {
+        KotorPatcher::Platform::Log("[KotorPatcher] ERROR: patcher initialization failed\n");
+    } else {
+        KotorPatcher::Platform::Log("[KotorPatcher] patcher initialized\n");
+    }
+}
+
+// Runs when the library is unloaded at process exit.
+__attribute__((destructor))
+void kpatchFini() {
+    KotorPatcher::CleanupPatcher();
+}
+
+} // namespace

--- a/src/KotorPatcher/src/platform_posix.cpp
+++ b/src/KotorPatcher/src/platform_posix.cpp
@@ -52,8 +52,9 @@ namespace Platform {
     }
 
     // Mapped writable, never writable+executable: macOS refuses that mapping, and
-    // these games are x86_64-only, so every Apple Silicon Mac runs them under
-    // Rosetta and would hit the refusal. ProtectExec flips the block to executable.
+    // the Aspyr macOS builds are x86_64, so every Apple Silicon Mac runs them
+    // under Rosetta and would hit the refusal. ProtectExec flips the block to
+    // executable.
     void* AllocExec(std::size_t size, std::uintptr_t nearAddress) {
         auto map = [size](void* hint) -> void* {
             void* mem = mmap(hint, size, PROT_READ | PROT_WRITE,
@@ -109,8 +110,8 @@ namespace Platform {
         // Writable and executable at once is asked for first, because it leaves the
         // page runnable throughout: the deferred-apply path patches while the game is
         // already running on other threads. Apple Silicon refuses that combination,
-        // and these games are x86_64-only so they always run there under Rosetta, so
-        // dropping execute for the duration of the write is the fallback.
+        // and the Aspyr macOS builds are x86_64 so they always run there under
+        // Rosetta, so dropping execute for the duration of the write is the fallback.
         if (mprotect(page, span, PROT_READ | PROT_WRITE | PROT_EXEC) != 0 &&
             mprotect(page, span, PROT_READ | PROT_WRITE) != 0) {
             return false;


### PR DESCRIPTION
Adds a `dylib` target to `src/KotorPatcher/Makefile`, and `src/dylibentry.cpp` to go with it. The Aspyr macOS releases of both games are x86_64 Mach-O.

The entry point is the same shape as the Linux one. Clang puts a constructor in `__DATA,__mod_init_func` and dyld runs it when it maps the library, for the same reasons the ELF loader runs an `.init_array` entry. It is the counterpart to what `dllmain.cpp` does on `DLL_PROCESS_ATTACH`.

### Building it

```
cd src/KotorPatcher
make dylib
```

You need the [osxcross toolchain](https://github.com/tpoechtrager/osxcross) on systems other than native macOS for `o64-clang++`, since building a Mach-O from Linux needs Apple's SDK and `ld64`. On an actual Mac, `make dylib CXX_MAC=clang++` instead. The target is deliberately kept out of `all`, so if you have not got the toolchain the DLL and the `.so` still build and nothing nags you about it.

### Per-architecture slices

`MAC_ARCHS` decides what goes in. It is `x86_64` today, which is the only thing the games need: both Aspyr builds are x86_64, and Apple Silicon runs them under Rosetta, which loads x86_64 slices.

Each architecture gets its own object directory and its own thin dylib, because the slices are compiled from overlapping sources for different instruction sets. The wrapper writer is picked per slice, since the 32-bit one is built on opcodes that do not exist in long mode. If there is more than one slice, `lipo` joins them; if there is only one, it is copied, because `lipo` on a single input still wraps it in a fat container and there is no reason to ship that.

Overriding `MAC_ARCHS` is not by itself enough to get another architecture, so the build says so rather than quietly producing something broken:

```
$ make dylib MAC_ARCHS="x86_64 arm64"
Makefile:101: *** No wrapper generator for macOS arch 'arm64'; set MAC_WRAPPER_arm64.  Stop.
```

`i386` already has a wrapper writer and would work, except that MacOSX14.sdk ships no 32-bit `libc++`, so it needs an older SDK. `arm64` needs both a wrapper writer and an arm64 trampoline, since the trampoline emits `E9`/`E8` by hand. Only worth doing if Aspyr ever ship a native build.

The deployment target is 10.9, the older of the two games' minimums, so the engine is never the thing that raises the bar. 
The macOS flags do not inherit the shared `COMMON` set, because `-s` and the `-static-libgcc`/`-static-libstdc++` pair are GCC options with no meaning to clang, and libc++ ships with the OS anyway.