### PR TITLE
Read, patch and re-sign Mach-O executables

### DIFF
--- a/src/KPatchCore/Applicators/ElfDependencies.cs
+++ b/src/KPatchCore/Applicators/ElfDependencies.cs
@@ -1,3 +1,4 @@
+using KPatchCore.Common;
 using KPatchCore.Models;
 using LibObjectFile.Elf;
 
@@ -81,13 +82,7 @@ internal sealed class ElfDependencies : IExecutableDependencies
                 using (var output = File.Create(tempPath))
                     elf.Write(output);
 
-                // The game executable is +x; carry its mode onto the temp file, or File.Move would
-                // hand over its default (non-executable) permissions. The guard satisfies CA1416:
-                // Get/SetUnixFileMode are Windows-unsupported, and this path only runs on Linux.
-                if (!OperatingSystem.IsWindows())
-                    File.SetUnixFileMode(tempPath, File.GetUnixFileMode(elfPath));
-
-                File.Move(tempPath, elfPath, overwrite: true);
+                PathHelpers.ReplacePreservingMode(tempPath, elfPath);
             }
             finally
             {

--- a/src/KPatchCore/Applicators/ExecutableDependencies.cs
+++ b/src/KPatchCore/Applicators/ExecutableDependencies.cs
@@ -41,6 +41,7 @@ public static class ExecutableDependencies
         return format.Data switch
         {
             ExecutableFormat.Elf => PatchResult<IExecutableDependencies>.Ok(new ElfDependencies(exePath)),
+            ExecutableFormat.MachO => PatchResult<IExecutableDependencies>.Ok(new MachODependencies(exePath)),
 
             // A PE's import table cannot be grown without moving what follows it, and a packed
             // executable would not honour the edit anyway. Windows reaches the same end through

--- a/src/KPatchCore/Applicators/MachODependencies.cs
+++ b/src/KPatchCore/Applicators/MachODependencies.cs
@@ -1,0 +1,158 @@
+using KPatchCore.Models;
+using KPatchCore.Parsers;
+using LibObjectFile.MachO;
+
+namespace KPatchCore.Applicators;
+
+/// <summary>
+/// The LC_LOAD_DYLIB list of a Mach-O executable. Adding to it costs only the space Apple's linker
+/// already left after the load commands, so nothing in the image moves and addresses patched
+/// beforehand stay valid.
+/// </summary>
+internal sealed class MachODependencies : IExecutableDependencies
+{
+    /// <summary>
+    /// dyld resolves this against the directory holding the executable, which is where the manager
+    /// stages the patcher. A bare name would be looked for on the system search paths instead. The
+    /// game already names libBink2Macx64.dylib this way, so the prefix is known to work here.
+    /// </summary>
+    private const string LoaderRelativePrefix = "@executable_path/";
+
+    private readonly string _exePath;
+
+    public MachODependencies(string exePath) => _exePath = exePath;
+
+    public PatchResult<bool> Contains(string moduleName)
+    {
+        if (!File.Exists(_exePath))
+            return PatchResult<bool>.Fail($"Executable not found: {_exePath}");
+
+        try
+        {
+            var image = Read();
+            var targets = image.Patchable.ToList();
+            if (targets.Count == 0)
+                return PatchResult<bool>.Fail(NoPatchableSliceMessage());
+
+            return PatchResult<bool>.Ok(targets.All(f => IsLinked(f, moduleName)));
+        }
+        catch (Exception ex)
+        {
+            return PatchResult<bool>.Fail($"Failed to read {Path.GetFileName(_exePath)}: {ex.Message}");
+        }
+    }
+
+    public PatchResult Add(string moduleName)
+    {
+        if (string.IsNullOrWhiteSpace(moduleName))
+            return PatchResult.Fail("Library name cannot be null or empty");
+        if (!File.Exists(_exePath))
+            return PatchResult.Fail($"Executable not found: {_exePath}");
+
+        var qualified = Qualify(moduleName);
+        var tempPath = _exePath + ".kpm-inject.tmp";
+
+        try
+        {
+            var image = Read();
+            var targets = image.Patchable.ToList();
+            if (targets.Count == 0)
+                return PatchResult.Fail(NoPatchableSliceMessage());
+
+            if (targets.All(f => IsLinked(f, moduleName)))
+                return PatchResult.Ok($"{qualified} is already a load command; nothing to do.");
+
+            foreach (var file in targets)
+            {
+                if (IsLinked(file, moduleName))
+                    continue;
+
+                // A load command is 24 bytes plus the name, padded. Refusing here beats writing an
+                // image whose commands run past the space the linker left for them.
+                var needed = 24 + qualified.Length + 1;
+                if (file.AvailableLoadCommandSpace < needed)
+                    return PatchResult.Fail(
+                        $"{Path.GetFileName(_exePath)} has {file.AvailableLoadCommandSpace} bytes of load " +
+                        $"command space left, and naming {qualified} needs about {needed}.");
+
+                file.AddLoadDylib(qualified);
+            }
+
+            image.ResignWhatWasSigned(MachOSigning.IdentifierFor(_exePath));
+
+            using (var output = File.Create(tempPath))
+                image.Write(output);
+
+            // Swapped in only once it is written, so a failed write never leaves a broken game.
+            File.Move(tempPath, _exePath, overwrite: true);
+            return PatchResult.Ok($"Added {qualified} to {Path.GetFileName(_exePath)}.");
+        }
+        catch (Exception ex)
+        {
+            try { File.Delete(tempPath); } catch { /* the original is still intact */ }
+            return PatchResult.Fail($"Failed to add {qualified} to {Path.GetFileName(_exePath)}: {ex.Message}");
+        }
+    }
+
+    private string Qualify(string moduleName) =>
+        moduleName.Contains('/') ? moduleName : LoaderRelativePrefix + moduleName;
+
+    /// <summary>Matches whether the name is written bare or with a loader-relative prefix.</summary>
+    private bool IsLinked(MachOFile file, string moduleName)
+    {
+        var bare = Path.GetFileName(moduleName);
+        return file.LinkedLibraries.Any(l =>
+            string.Equals(Path.GetFileName(l.Value), bare, StringComparison.Ordinal));
+    }
+
+    private string NoPatchableSliceMessage() =>
+        $"{Path.GetFileName(_exePath)} has no x86_64 slice, which is the architecture the patcher is built for.";
+
+    private Image Read()
+    {
+        using var stream = File.OpenRead(_exePath);
+        if (MachOFatFile.IsFat(stream))
+        {
+            stream.Position = 0;
+            return new Image(MachOFatFile.Read(stream), null);
+        }
+
+        stream.Position = 0;
+        return new Image(null, MachOFile.Read(stream));
+    }
+
+    /// <summary>A Mach-O read from disk, universal or thin, so callers stop caring which.</summary>
+    private sealed record Image(MachOFatFile? Fat, MachOFile? Thin)
+    {
+        /// <summary>
+        /// The slices worth naming the patcher in. Only x86_64: it is what the engine is built for,
+        /// and what every 64-bit Mac runs. Naming it in an i386 slice would leave that slice unable
+        /// to start at all, since no i386 patcher exists to find.
+        /// </summary>
+        public IEnumerable<MachOFile> Patchable =>
+            Fat is not null
+                ? Fat.Slices.Where(s => s.File is not null && s.CpuType == MachOCpuType.X86_64).Select(s => s.File!)
+                : Thin is { CpuType: MachOCpuType.X86_64 } ? new[] { Thin } : Array.Empty<MachOFile>();
+
+        public void ResignWhatWasSigned(string identifier)
+        {
+            if (Fat is not null)
+                MachOSigning.ResignWhatWasSigned(Fat, identifier);
+            else
+                MachOSigning.ResignWhatWasSigned(Thin!, identifier);
+        }
+
+        public void Write(Stream stream)
+        {
+            if (Fat is not null)
+            {
+                Fat.UpdateLayout();
+                Fat.Write(stream);
+            }
+            else
+            {
+                Thin!.Write(stream);
+            }
+        }
+    }
+}

--- a/src/KPatchCore/Applicators/MachODependencies.cs
+++ b/src/KPatchCore/Applicators/MachODependencies.cs
@@ -1,3 +1,4 @@
+using KPatchCore.Common;
 using KPatchCore.Models;
 using KPatchCore.Parsers;
 using LibObjectFile.MachO;
@@ -84,7 +85,7 @@ internal sealed class MachODependencies : IExecutableDependencies
                 image.Write(output);
 
             // Swapped in only once it is written, so a failed write never leaves a broken game.
-            File.Move(tempPath, _exePath, overwrite: true);
+            PathHelpers.ReplacePreservingMode(tempPath, _exePath);
             return PatchResult.Ok($"Added {qualified} to {Path.GetFileName(_exePath)}.");
         }
         catch (Exception ex)

--- a/src/KPatchCore/Applicators/StaticHookApplicator.cs
+++ b/src/KPatchCore/Applicators/StaticHookApplicator.cs
@@ -84,6 +84,15 @@ public static class StaticHookApplicator
             appliedCount++;
         }
 
+        // Some formats carry integrity metadata that the writes above invalidate. A macOS binary's
+        // signature is one, and the kernel checks it at exec, so skipping this would leave a game
+        // that no longer starts.
+        var completeResult = image.Complete();
+        if (!completeResult.Success)
+        {
+            errors.Add(completeResult.Error!);
+        }
+
         // If any errors occurred, return failure
         if (errors.Count > 0)
         {

--- a/src/KPatchCore/Common/PathHelpers.cs
+++ b/src/KPatchCore/Common/PathHelpers.cs
@@ -133,6 +133,31 @@ public static class PathHelpers
     }
 
     /// <summary>
+    /// Moves a rewritten file over the one it replaces, carrying the original's permissions with
+    /// it. A freshly created file gets default permissions, so a plain move leaves a game
+    /// executable that is no longer executable and a game that will not start.
+    /// </summary>
+    /// <remarks>
+    /// Only whole-file rewrites need this. Byte patching writes through the existing file, where
+    /// the mode is never at risk.
+    ///
+    /// A Windows host cannot do it: SetUnixFileMode throws there, so patching a Linux or macOS
+    /// install from Windows leaves the executable bit to whatever the filesystem hands out.
+    /// Writing in place rather than replacing would avoid that, but it gives up the property this
+    /// exists for, a failed write leaving the original intact, which is the only safety net when
+    /// the caller has backups turned off.
+    /// </remarks>
+    public static void ReplacePreservingMode(string tempPath, string destinationPath)
+    {
+        // Get/SetUnixFileMode are unsupported on Windows, which has no executable bit to carry.
+        // The guard also satisfies CA1416.
+        if (!OperatingSystem.IsWindows())
+            File.SetUnixFileMode(tempPath, File.GetUnixFileMode(destinationPath));
+
+        File.Move(tempPath, destinationPath, overwrite: true);
+    }
+
+    /// <summary>
     /// Creates a temporary directory with a unique name
     /// </summary>
     public static string CreateTempDirectory()

--- a/src/KPatchCore/KPatchCore.csproj
+++ b/src/KPatchCore/KPatchCore.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibObjectFile" Version="2.2.0" />
+    <PackageReference Include="LibObjectFile" Version="2.3.1" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.0" />
     <PackageReference Include="System.IO.Compression" Version="4.3.0" />
     <PackageReference Include="Tomlyn" Version="0.19.0" />

--- a/src/KPatchCore/Models/Hook.cs
+++ b/src/KPatchCore/Models/Hook.cs
@@ -32,9 +32,10 @@ public enum HookType
 public sealed class Hook
 {
     /// <summary>
-    /// Memory address to hook (e.g., 0x401234)
+    /// Absolute virtual address to hook (e.g., 0x401234). Wide enough for a 64-bit
+    /// Mach-O, whose image sits above a 4 GB __PAGEZERO and so starts at 0x100000000.
     /// </summary>
-    public required uint Address { get; init; }
+    public required ulong Address { get; init; }
 
     /// <summary>
     /// Exported function name in patch DLL
@@ -104,7 +105,7 @@ public sealed class Hook
     /// must match stack state at the natural fall-through point.
     /// Default: null (feature disabled — wrapper always uses fall-through path).
     /// </summary>
-    public uint? ConsumedExitAddress { get; init; }
+    public ulong? ConsumedExitAddress { get; init; }
 
     /// <summary>
     /// Validates that the hook configuration is valid

--- a/src/KPatchCore/Parsers/ElfExecutableImage.cs
+++ b/src/KPatchCore/Parsers/ElfExecutableImage.cs
@@ -90,6 +90,9 @@ internal sealed class ElfExecutableImage : IExecutableImage
         }
     }
 
+    /// <summary>An ELF carries nothing that a size-preserving byte write invalidates.</summary>
+    public PatchResult Complete() => PatchResult.Ok();
+
     public PatchResult WriteAtVirtualAddress(ulong virtualAddress, byte[] bytes)
     {
         if (bytes == null || bytes.Length == 0)

--- a/src/KPatchCore/Parsers/ElfExecutableImage.cs
+++ b/src/KPatchCore/Parsers/ElfExecutableImage.cs
@@ -48,7 +48,7 @@ internal sealed class ElfExecutableImage : IExecutableImage
         }
     }
 
-    private PatchResult<long> ToFileOffset(uint virtualAddress, int length)
+    private PatchResult<long> ToFileOffset(ulong virtualAddress, int length)
     {
         foreach (var seg in _loads)
         {
@@ -66,7 +66,7 @@ internal sealed class ElfExecutableImage : IExecutableImage
         return PatchResult<long>.Fail($"Virtual address 0x{virtualAddress:X8} is not mapped by any PT_LOAD segment.");
     }
 
-    public PatchResult<byte[]> ReadAtVirtualAddress(uint virtualAddress, int length)
+    public PatchResult<byte[]> ReadAtVirtualAddress(ulong virtualAddress, int length)
     {
         if (length <= 0)
             return PatchResult<byte[]>.Fail($"Invalid length: {length}");
@@ -90,7 +90,7 @@ internal sealed class ElfExecutableImage : IExecutableImage
         }
     }
 
-    public PatchResult WriteAtVirtualAddress(uint virtualAddress, byte[] bytes)
+    public PatchResult WriteAtVirtualAddress(ulong virtualAddress, byte[] bytes)
     {
         if (bytes == null || bytes.Length == 0)
             return PatchResult.Fail("Bytes cannot be null or empty");

--- a/src/KPatchCore/Parsers/ExecutableImage.cs
+++ b/src/KPatchCore/Parsers/ExecutableImage.cs
@@ -9,10 +9,10 @@ namespace KPatchCore.Parsers;
 internal interface IExecutableImage
 {
     /// <summary>Reads <paramref name="length"/> bytes located at <paramref name="virtualAddress"/>.</summary>
-    PatchResult<byte[]> ReadAtVirtualAddress(uint virtualAddress, int length);
+    PatchResult<byte[]> ReadAtVirtualAddress(ulong virtualAddress, int length);
 
     /// <summary>Writes <paramref name="bytes"/> at <paramref name="virtualAddress"/>.</summary>
-    PatchResult WriteAtVirtualAddress(uint virtualAddress, byte[] bytes);
+    PatchResult WriteAtVirtualAddress(ulong virtualAddress, byte[] bytes);
 }
 
 /// <summary>

--- a/src/KPatchCore/Parsers/ExecutableImage.cs
+++ b/src/KPatchCore/Parsers/ExecutableImage.cs
@@ -31,6 +31,7 @@ internal static class ExecutableImage
         {
             ExecutableFormat.Elf => ElfExecutableImage.Open(exePath),
             ExecutableFormat.Pe => PeExecutableImage.Open(exePath),
+            ExecutableFormat.MachO => MachOExecutableImage.Open(exePath),
             _ => PatchResult<IExecutableImage>.Fail(
                 $"{Path.GetFileName(exePath)} is a {format.Data} executable, which byte patching does not support yet."),
         };

--- a/src/KPatchCore/Parsers/ExecutableImage.cs
+++ b/src/KPatchCore/Parsers/ExecutableImage.cs
@@ -13,6 +13,14 @@ internal interface IExecutableImage
 
     /// <summary>Writes <paramref name="bytes"/> at <paramref name="virtualAddress"/>.</summary>
     PatchResult WriteAtVirtualAddress(ulong virtualAddress, byte[] bytes);
+
+    /// <summary>
+    /// Finishes the edit. A format whose file carries integrity metadata repairs it here, so this
+    /// has to be called once after the last write; a format with nothing to repair succeeds without
+    /// touching the file. Writing again afterwards is not supported, because the repair can move
+    /// whatever follows the edited bytes.
+    /// </summary>
+    PatchResult Complete();
 }
 
 /// <summary>

--- a/src/KPatchCore/Parsers/HooksParser.cs
+++ b/src/KPatchCore/Parsers/HooksParser.cs
@@ -107,7 +107,7 @@ public static class HooksParser
                 var hookTable = hooksArray[i];
 
                 // Parse required fields
-                if (!TryGetUInt(hookTable, "address", out var address))
+                if (!TryGetULong(hookTable, "address", out var address))
                 {
                     return PatchResult<List<Hook>>.Fail($"Hook [{i}] missing required field: address");
                 }
@@ -144,8 +144,8 @@ public static class HooksParser
                 var excludeFromRestore = TryGetStringArray(hookTable, "exclude_from_restore") ?? new List<string>();
                 var skipOriginalBytes = TryGetBool(hookTable, "skip_original_bytes") ?? false;
 
-                uint? consumedExitAddress = null;
-                if (TryGetUInt(hookTable, "consumed_exit_address", out var consumedExit) && consumedExit != 0)
+                ulong? consumedExitAddress = null;
+                if (TryGetULong(hookTable, "consumed_exit_address", out var consumedExit) && consumedExit != 0)
                 {
                     consumedExitAddress = consumedExit;
                 }
@@ -203,25 +203,22 @@ public static class HooksParser
         return false;
     }
 
-    private static bool TryGetUInt(TomlTable table, string key, out uint value)
+    private static bool TryGetULong(TomlTable table, string key, out ulong value)
     {
-        if (table.TryGetValue(key, out var obj))
-        {
-            // TOML numbers can be long or int
-            if (obj is long longVal)
-            {
-                value = (uint)longVal;
-                return true;
-            }
-            else if (obj is int intVal)
-            {
-                value = (uint)intVal;
-                return true;
-            }
-        }
-
+        // The old narrowing cast here turned a Mach-O address such as 0x1004EB6C2 into
+        // 0x004EB6C2, which is a plausible-looking address somewhere else in the image.
+        // A value that is not a non-negative integer is rejected instead.
         value = 0;
-        return false;
+
+        if (!table.TryGetValue(key, out var obj))
+            return false;
+
+        switch (obj)
+        {
+            case long l when l >= 0: value = (ulong)l; return true;
+            case int i when i >= 0: value = (ulong)i; return true;
+            default: return false;
+        }
     }
 
     private static bool? TryGetBool(TomlTable table, string key)

--- a/src/KPatchCore/Parsers/MachOExecutableImage.cs
+++ b/src/KPatchCore/Parsers/MachOExecutableImage.cs
@@ -17,6 +17,7 @@ internal sealed class MachOExecutableImage : IExecutableImage
     private readonly string _exePath;
     private readonly List<MappedRange> _ranges;
     private readonly bool _isSigned;
+    private bool _modified;
 
     private MachOExecutableImage(string exePath, List<MappedRange> ranges, bool isSigned)
     {
@@ -114,6 +115,66 @@ internal sealed class MachOExecutableImage : IExecutableImage
         return PatchResult<long>.Ok((long)(found.ContainerOffset + offsetInSegment));
     }
 
+    /// <summary>
+    /// Re-signs the image when the edits above invalidated a signature it already carried. The
+    /// kernel checks that signature when it execs the binary, not only when Gatekeeper assesses
+    /// it, so a patched game would otherwise stop starting.
+    /// </summary>
+    /// <remarks>
+    /// Whether to sign is a property of the file, never of which game it is: an image that arrived
+    /// unsigned stays unsigned, and one that was not written to is left exactly as it was, since
+    /// re-signing it would trade the vendor's signature for an ad-hoc one and gain nothing.
+    /// </remarks>
+    public PatchResult Complete()
+    {
+        if (!_modified || !_isSigned)
+            return PatchResult.Ok();
+
+        // codesign uses the file name without its extension as the default identifier, which is
+        // what these binaries already carry. The reader does not expose the existing one to copy.
+        var identifier = Path.GetFileNameWithoutExtension(_exePath);
+        var tempPath = _exePath + ".kpm-sign.tmp";
+
+        try
+        {
+            using (var input = File.OpenRead(_exePath))
+            using (var output = File.Create(tempPath))
+            {
+                if (MachOFatFile.IsFat(input))
+                {
+                    input.Position = 0;
+                    var fat = MachOFatFile.Read(input);
+
+                    // Each slice carries its own signature, and a slice that had none keeps none.
+                    foreach (var slice in fat.Slices)
+                    {
+                        if (slice.File?.CodeSignature is not null)
+                            slice.File.AdHocSign(identifier);
+                    }
+
+                    fat.UpdateLayout();
+                    fat.Write(output);
+                }
+                else
+                {
+                    input.Position = 0;
+                    var file = MachOFile.Read(input);
+                    file.AdHocSign(identifier);
+                    file.Write(output);
+                }
+            }
+
+            // Swapped in only once it is written, so a failure never leaves a half-signed binary.
+            File.Move(tempPath, _exePath, overwrite: true);
+            return PatchResult.Ok();
+        }
+        catch (Exception ex)
+        {
+            try { File.Delete(tempPath); } catch { /* the original is still intact */ }
+            return PatchResult.Fail($"Failed to re-sign {Path.GetFileName(_exePath)}: {ex.Message}");
+        }
+    }
+
     public PatchResult<byte[]> ReadAtVirtualAddress(ulong virtualAddress, int length)
     {
         if (length <= 0)
@@ -143,14 +204,6 @@ internal sealed class MachOExecutableImage : IExecutableImage
         if (bytes == null || bytes.Length == 0)
             return PatchResult.Fail("Bytes cannot be null or empty");
 
-        // The kernel checks a signed binary's signature when it execs it, not just when Gatekeeper
-        // assesses it, so editing one produces a game that will not start. K1's KOTOR_Exe is signed;
-        // K2's KOTOR2sub is not.
-        if (_isSigned)
-            return PatchResult.Fail(
-                $"{Path.GetFileName(_exePath)} carries a code signature, and editing its bytes would " +
-                "leave a binary the kernel refuses to run.");
-
         var offset = ToFileOffset(virtualAddress, bytes.Length);
         if (!offset.Success)
             return PatchResult.Fail(offset.Error!);
@@ -161,6 +214,7 @@ internal sealed class MachOExecutableImage : IExecutableImage
             stream.Seek(offset.Data, SeekOrigin.Begin);
             stream.Write(bytes, 0, bytes.Length);
             stream.Flush();
+            _modified = true;
             return PatchResult.Ok();
         }
         catch (Exception ex)

--- a/src/KPatchCore/Parsers/MachOExecutableImage.cs
+++ b/src/KPatchCore/Parsers/MachOExecutableImage.cs
@@ -130,9 +130,7 @@ internal sealed class MachOExecutableImage : IExecutableImage
         if (!_modified || !_isSigned)
             return PatchResult.Ok();
 
-        // codesign uses the file name without its extension as the default identifier, which is
-        // what these binaries already carry. The reader does not expose the existing one to copy.
-        var identifier = Path.GetFileNameWithoutExtension(_exePath);
+        var identifier = MachOSigning.IdentifierFor(_exePath);
         var tempPath = _exePath + ".kpm-sign.tmp";
 
         try
@@ -145,13 +143,7 @@ internal sealed class MachOExecutableImage : IExecutableImage
                     input.Position = 0;
                     var fat = MachOFatFile.Read(input);
 
-                    // Each slice carries its own signature, and a slice that had none keeps none.
-                    foreach (var slice in fat.Slices)
-                    {
-                        if (slice.File?.CodeSignature is not null)
-                            slice.File.AdHocSign(identifier);
-                    }
-
+                    MachOSigning.ResignWhatWasSigned(fat, identifier);
                     fat.UpdateLayout();
                     fat.Write(output);
                 }
@@ -159,7 +151,7 @@ internal sealed class MachOExecutableImage : IExecutableImage
                 {
                     input.Position = 0;
                     var file = MachOFile.Read(input);
-                    file.AdHocSign(identifier);
+                    MachOSigning.ResignWhatWasSigned(file, identifier);
                     file.Write(output);
                 }
             }

--- a/src/KPatchCore/Parsers/MachOExecutableImage.cs
+++ b/src/KPatchCore/Parsers/MachOExecutableImage.cs
@@ -1,0 +1,171 @@
+using KPatchCore.Models;
+using LibObjectFile.MachO;
+
+namespace KPatchCore.Parsers;
+
+/// <summary>
+/// <see cref="IExecutableImage"/> over a Mach-O executable, thin or universal. A virtual address maps
+/// to a file offset via offset = slice.FileOffset + segment.FileOffset + (va - segment.VmAddress),
+/// where the slice offset is zero for a thin file. The byte read/write is a direct, size-preserving
+/// file edit, so it never triggers a layout rewrite of the executable.
+/// </summary>
+internal sealed class MachOExecutableImage : IExecutableImage
+{
+    /// <summary>A segment's file-backed bytes, with the offset already relative to the container.</summary>
+    private readonly record struct MappedRange(ulong VmAddress, ulong ContainerOffset, ulong FileSize);
+
+    private readonly string _exePath;
+    private readonly List<MappedRange> _ranges;
+    private readonly bool _isSigned;
+
+    private MachOExecutableImage(string exePath, List<MappedRange> ranges, bool isSigned)
+    {
+        _exePath = exePath;
+        _ranges = ranges;
+        _isSigned = isSigned;
+    }
+
+    public static PatchResult<IExecutableImage> Open(string exePath)
+    {
+        try
+        {
+            var ranges = new List<MappedRange>();
+            var isSigned = false;
+
+            using var stream = File.OpenRead(exePath);
+            if (MachOFatFile.IsFat(stream))
+            {
+                stream.Position = 0;
+                foreach (var slice in MachOFatFile.Read(stream).Slices)
+                {
+                    if (slice.File is null)
+                        continue;
+
+                    Collect(slice.File, slice.FileOffset, ranges);
+                    isSigned |= slice.File.CodeSignature is not null;
+                }
+            }
+            else
+            {
+                stream.Position = 0;
+                var file = MachOFile.Read(stream);
+                Collect(file, 0, ranges);
+                isSigned = file.CodeSignature is not null;
+            }
+
+            if (ranges.Count == 0)
+                return PatchResult<IExecutableImage>.Fail($"{Path.GetFileName(exePath)} has no file-backed segments.");
+
+            return PatchResult<IExecutableImage>.Ok(new MachOExecutableImage(exePath, ranges, isSigned));
+        }
+        catch (Exception ex)
+        {
+            return PatchResult<IExecutableImage>.Fail($"Failed to parse Mach-O: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Adds the segments that actually occupy bytes in the file. A segment with no file content maps
+    /// nothing, which drops __PAGEZERO: it claims the whole 4 GB below the image and would otherwise
+    /// swallow every address handed to it.
+    /// </summary>
+    private static void Collect(MachOFile file, ulong sliceOffset, List<MappedRange> into)
+    {
+        foreach (var segment in file.Segments)
+        {
+            if (segment.FileSize == 0)
+                continue;
+
+            into.Add(new MappedRange(segment.VmAddress, sliceOffset + segment.FileOffset, segment.FileSize));
+        }
+    }
+
+    private PatchResult<long> ToFileOffset(ulong virtualAddress, int length)
+    {
+        MappedRange? match = null;
+
+        foreach (var range in _ranges)
+        {
+            if (virtualAddress < range.VmAddress || virtualAddress >= range.VmAddress + range.FileSize)
+                continue;
+
+            // The slices of a universal binary do not share an address space: a 64-bit slice sits
+            // above its 4 GB __PAGEZERO while a 32-bit one starts just above a 4 KB one, so an
+            // address names exactly one of them and no architecture has to be given. Should a build
+            // ever break that, the mapping is refused rather than guessed, because writing to the
+            // wrong slice would put one instruction set's bytes over another's.
+            if (match is not null)
+                return PatchResult<long>.Fail(
+                    $"Virtual address 0x{virtualAddress:X8} is claimed by more than one slice of " +
+                    $"{Path.GetFileName(_exePath)}, so which one to patch is ambiguous.");
+
+            match = range;
+        }
+
+        if (match is null)
+            return PatchResult<long>.Fail($"Virtual address 0x{virtualAddress:X8} is not mapped by any segment.");
+
+        var found = match.Value;
+        ulong offsetInSegment = virtualAddress - found.VmAddress;
+        if (offsetInSegment + (uint)length > found.FileSize)
+            return PatchResult<long>.Fail(
+                $"Virtual address 0x{virtualAddress:X8} + {length} bytes runs past its segment's file range.");
+
+        return PatchResult<long>.Ok((long)(found.ContainerOffset + offsetInSegment));
+    }
+
+    public PatchResult<byte[]> ReadAtVirtualAddress(ulong virtualAddress, int length)
+    {
+        if (length <= 0)
+            return PatchResult<byte[]>.Fail($"Invalid length: {length}");
+
+        var offset = ToFileOffset(virtualAddress, length);
+        if (!offset.Success)
+            return PatchResult<byte[]>.Fail(offset.Error!);
+
+        try
+        {
+            using var stream = File.OpenRead(_exePath);
+            stream.Seek(offset.Data, SeekOrigin.Begin);
+            var bytes = new byte[length];
+            if (stream.Read(bytes, 0, length) != length)
+                return PatchResult<byte[]>.Fail($"Short read at 0x{virtualAddress:X8}.");
+            return PatchResult<byte[]>.Ok(bytes);
+        }
+        catch (Exception ex)
+        {
+            return PatchResult<byte[]>.Fail($"Failed to read bytes: {ex.Message}");
+        }
+    }
+
+    public PatchResult WriteAtVirtualAddress(ulong virtualAddress, byte[] bytes)
+    {
+        if (bytes == null || bytes.Length == 0)
+            return PatchResult.Fail("Bytes cannot be null or empty");
+
+        // The kernel checks a signed binary's signature when it execs it, not just when Gatekeeper
+        // assesses it, so editing one produces a game that will not start. K1's KOTOR_Exe is signed;
+        // K2's KOTOR2sub is not.
+        if (_isSigned)
+            return PatchResult.Fail(
+                $"{Path.GetFileName(_exePath)} carries a code signature, and editing its bytes would " +
+                "leave a binary the kernel refuses to run.");
+
+        var offset = ToFileOffset(virtualAddress, bytes.Length);
+        if (!offset.Success)
+            return PatchResult.Fail(offset.Error!);
+
+        try
+        {
+            using var stream = File.Open(_exePath, FileMode.Open, FileAccess.ReadWrite);
+            stream.Seek(offset.Data, SeekOrigin.Begin);
+            stream.Write(bytes, 0, bytes.Length);
+            stream.Flush();
+            return PatchResult.Ok();
+        }
+        catch (Exception ex)
+        {
+            return PatchResult.Fail($"Failed to write bytes: {ex.Message}");
+        }
+    }
+}

--- a/src/KPatchCore/Parsers/MachOExecutableImage.cs
+++ b/src/KPatchCore/Parsers/MachOExecutableImage.cs
@@ -1,3 +1,4 @@
+using KPatchCore.Common;
 using KPatchCore.Models;
 using LibObjectFile.MachO;
 
@@ -157,7 +158,7 @@ internal sealed class MachOExecutableImage : IExecutableImage
             }
 
             // Swapped in only once it is written, so a failure never leaves a half-signed binary.
-            File.Move(tempPath, _exePath, overwrite: true);
+            PathHelpers.ReplacePreservingMode(tempPath, _exePath);
             return PatchResult.Ok();
         }
         catch (Exception ex)

--- a/src/KPatchCore/Parsers/MachOSigning.cs
+++ b/src/KPatchCore/Parsers/MachOSigning.cs
@@ -1,0 +1,48 @@
+using LibObjectFile.MachO;
+
+namespace KPatchCore.Parsers;
+
+/// <summary>
+/// The one rule for putting a Mach-O's signature back after editing it, shared by everything that
+/// writes one so the two cannot drift apart.
+/// </summary>
+/// <remarks>
+/// Ad hoc is enough because the kernel checks a binary's own signature when it execs it, and an
+/// ad-hoc one satisfies that. It does not satisfy the bundle seal: Contents/_CodeSignature/
+/// CodeResources names the executable with a cdhash and a requirement pinning Aspyr's team
+/// identifier, and both stop matching the moment we patch. Nothing on the launch path reads that
+/// seal, restoring the backup makes it valid again, and repairing it would need Aspyr's
+/// certificate, so it is left alone.
+///
+/// All of that holds only while the game ships with CodeDirectory flags of 0. Hardened runtime or
+/// library validation would refuse to load an unsigned KotorPatcher.dylib whatever is signed here.
+/// </remarks>
+internal static class MachOSigning
+{
+    /// <summary>
+    /// codesign uses the file name without its extension as the default identifier, and it is what
+    /// these binaries already carry. The reader does not expose the existing one to copy.
+    /// </summary>
+    public static string IdentifierFor(string exePath) => Path.GetFileNameWithoutExtension(exePath);
+
+    /// <summary>
+    /// Re-signs ad hoc, and only where a signature already existed. A file that arrived unsigned
+    /// stays unsigned: giving it one would change what the loader checks for no reason.
+    /// </summary>
+    public static void ResignWhatWasSigned(MachOFile file, string identifier)
+    {
+        if (file.CodeSignature is not null)
+            file.AdHocSign(identifier);
+    }
+
+    /// <inheritdoc cref="ResignWhatWasSigned(MachOFile, string)"/>
+    /// <remarks>Each slice of a universal binary carries its own signature.</remarks>
+    public static void ResignWhatWasSigned(MachOFatFile fat, string identifier)
+    {
+        foreach (var slice in fat.Slices)
+        {
+            if (slice.File is not null)
+                ResignWhatWasSigned(slice.File, identifier);
+        }
+    }
+}

--- a/src/KPatchCore/Parsers/PeExecutableImage.cs
+++ b/src/KPatchCore/Parsers/PeExecutableImage.cs
@@ -26,9 +26,39 @@ internal sealed class PeExecutableImage : IExecutableImage
         return PatchResult<IExecutableImage>.Ok(new PeExecutableImage(exePath, parsed.Data));
     }
 
-    public PatchResult<byte[]> ReadAtVirtualAddress(uint virtualAddress, int length) =>
-        PeHeaderParser.ReadBytesAtVirtualAddress(_exePath, _info, virtualAddress, length);
+    public PatchResult<byte[]> ReadAtVirtualAddress(ulong virtualAddress, int length)
+    {
+        if (!TryNarrow(virtualAddress, out var va, out var error))
+            return PatchResult<byte[]>.Fail(error!);
 
-    public PatchResult WriteAtVirtualAddress(uint virtualAddress, byte[] bytes) =>
-        PeHeaderParser.WriteBytesToVirtualAddress(_exePath, _info, virtualAddress, bytes);
+        return PeHeaderParser.ReadBytesAtVirtualAddress(_exePath, _info, va, length);
+    }
+
+    public PatchResult WriteAtVirtualAddress(ulong virtualAddress, byte[] bytes)
+    {
+        if (!TryNarrow(virtualAddress, out var va, out var error))
+            return PatchResult.Fail(error!);
+
+        return PeHeaderParser.WriteBytesToVirtualAddress(_exePath, _info, va, bytes);
+    }
+
+    /// <summary>
+    /// Addresses are carried as 64-bit because a Mach-O image needs it, but the PE
+    /// builds of these games are 32-bit. An address that does not fit one is not an
+    /// address in this file, so it is refused rather than narrowed into a
+    /// plausible-looking one somewhere else in the image.
+    /// </summary>
+    private static bool TryNarrow(ulong virtualAddress, out uint narrowed, out string? error)
+    {
+        if (virtualAddress > uint.MaxValue)
+        {
+            narrowed = 0;
+            error = $"Address 0x{virtualAddress:X} is outside the 32-bit range of a PE image.";
+            return false;
+        }
+
+        narrowed = (uint)virtualAddress;
+        error = null;
+        return true;
+    }
 }

--- a/src/KPatchCore/Parsers/PeExecutableImage.cs
+++ b/src/KPatchCore/Parsers/PeExecutableImage.cs
@@ -34,6 +34,12 @@ internal sealed class PeExecutableImage : IExecutableImage
         return PeHeaderParser.ReadBytesAtVirtualAddress(_exePath, _info, va, length);
     }
 
+    /// <summary>
+    /// The KOTOR PE builds are unsigned, and their header checksum is not enforced for an
+    /// executable image, so a byte write leaves nothing to repair.
+    /// </summary>
+    public PatchResult Complete() => PatchResult.Ok();
+
     public PatchResult WriteAtVirtualAddress(ulong virtualAddress, byte[] bytes)
     {
         if (!TryNarrow(virtualAddress, out var va, out var error))

--- a/src/KPatchCore/Validators/HookValidator.cs
+++ b/src/KPatchCore/Validators/HookValidator.cs
@@ -7,9 +7,19 @@ namespace KPatchCore.Validators;
 /// </summary>
 public static class HookValidator
 {
-    // Typical Windows executable address range for 32-bit applications
-    private const uint MinAddress = 0x00400000;
-    private const uint MaxAddress = 0x7FFFFFFF;
+    // A hook address is an absolute virtual address in the game image. These windows
+    // exist to catch a mistyped or truncated address, not to bound the image exactly.
+    // The 32-bit targets sit in the low 2 GB: a Windows PE at 0x400000, the Linux ELF
+    // at 0x8048000. A 64-bit Mach-O is fixed just above its 4 GB __PAGEZERO, which is
+    // what puts a macOS hook at 0x1004EB6C2 rather than 0x4EB6C2.
+    private const ulong MinAddress = 0x00400000;
+    private const ulong MaxAddress = 0x7FFFFFFF;
+    private const ulong MinMachOAddress = 0x1_00000000;
+    private const ulong MaxMachOAddress = 0x1_FFFFFFFF;
+
+    private static bool IsPlausibleImageAddress(ulong address) =>
+        (address >= MinAddress && address <= MaxAddress) ||
+        (address >= MinMachOAddress && address <= MaxMachOAddress);
 
     /// <summary>
     /// Validates a single hook
@@ -25,11 +35,11 @@ public static class HookValidator
         }
 
         // Additional address range check
-        if (hook.Address < MinAddress || hook.Address > MaxAddress)
+        if (!IsPlausibleImageAddress(hook.Address))
         {
             return PatchResult.Fail(
-                $"Hook address 0x{hook.Address:X8} is outside typical executable range " +
-                $"(0x{MinAddress:X8} - 0x{MaxAddress:X8})"
+                $"Hook address 0x{hook.Address:X8} is outside the ranges a game image occupies " +
+                $"(0x{MinAddress:X8}-0x{MaxAddress:X8}, or 0x{MinMachOAddress:X8}-0x{MaxMachOAddress:X8} for a 64-bit Mach-O)"
             );
         }
 
@@ -181,7 +191,7 @@ public static class HookValidator
             if (hook.OriginalBytes[i] != actualBytes[i])
             {
                 return PatchResult.Fail(
-                    $"Byte mismatch at address 0x{hook.Address + i:X8} " +
+                    $"Byte mismatch at address 0x{hook.Address + (ulong)i:X8} " +
                     $"(expected 0x{hook.OriginalBytes[i]:X2}, got 0x{actualBytes[i]:X2}). " +
                     $"This may indicate a different game version or an already-patched executable."
                 );


### PR DESCRIPTION
#195 taught the manager that Mach-O exists. It detects the magic number, has an `ExecutableFormat.MachO` to name it, and then refuses to do anything with it. #198 built `KotorPatcher.dylib` for the games to load. This fills in the middle: reading, patching and re-signing the executable itself.

### What it does

Four things, all behind seams that already exist:

- **`MachOExecutableImage`** maps a virtual address to a file offset and reads or writes there. That is what STATIC hooks need. It handles thin and universal binaries, and it drops `__PAGEZERO`, which claims the whole 4 GB below the image and would otherwise swallow every address handed to it.
- **`MachODependencies`** adds `LC_LOAD_DYLIB` so the loader maps the patcher at startup, the same way the Linux build names `KotorPatcher.so` in its `DT_NEEDED` list. It costs only the space Apple's linker already left after the load commands, so nothing in the image moves and any addresses patched beforehand stay valid. It checks that space is there before writing rather than producing an image whose commands run past it.
- **`MachOSigning`** puts the signature back afterwards, ad hoc, and only where one already existed.
- **`Complete()`** on `IExecutableImage`. A format whose file carries integrity metadata repairs it there once the last write is done; PE and ELF have nothing to repair and return success without touching the file.

Hook addresses widen from 32 to 64 bits along the way, since a macOS image sits above `0x100000000`. A config address is parsed as 64-bit and narrowed once, and one that will not fit is refused rather than truncated into a different, perfectly plausible address in the same image.

### Why re-signing matters, and what it does not fix

macOS checks a binary's signature when it execs it, not just when Gatekeeper looks at it. Patch the bytes without repairing the signature and the game stops starting. An ad-hoc signature satisfies that check, and we can produce one without any certificate.

What it does not satisfy is the bundle seal. `Contents/_CodeSignature/CodeResources` names the executable with a hash and a requirement pinning Aspyr's team identifier, and both stop matching the moment we patch. That is left alone deliberately: nothing on the launch path reads it, restoring the backup makes it valid again, and repairing it would need Aspyr's certificate anyway. `codesign --verify --deep` on a patched install will fail, and that is expected.

There is one assumption underneath all of this, so it is written down next to the code: it works because the game ships with CodeDirectory flags of `0`. Hardened runtime or library validation would refuse to load an unsigned `KotorPatcher.dylib` no matter what we sign here. This will most likely come back to bite us if we try and patch AppStore releases.

### A limitation worth knowing about

Whole-file rewrites replace the executable, and a fresh file gets default permissions, so the original's mode has to be carried across or the game is left non-executable. `ReplacePreservingMode` does that. A Windows host cannot: `SetUnixFileMode` throws there, so patching a Linux or macOS install from Windows leaves the executable bit to whatever the filesystem hands out.

Byte patching is unaffected, since it writes through the existing file and never replaces it. Writing in place everywhere would avoid the problem entirely, but it gives up the property this exists for, a failed write leaving the original intact, which is the only safety net when the caller has backups turned off. So the limitation is documented where the mechanism lives, and telling the user about it belongs with the rest of the platform wiring in the next PR.

### What is not here

Recognising a macOS install, finding the game inside an `.app` bundle, routing the deployment to the dylib, the launcher. That is all manager behaviour and it is the next PR. This one only teaches the existing seams how to handle the format, which is why it cannot be driven end to end on its own.