### PR TITLE
Fix patch load order buttons

### DIFF
--- a/src/KPatchCore/Validators/DependencyValidator.cs
+++ b/src/KPatchCore/Validators/DependencyValidator.cs
@@ -128,12 +128,16 @@ public static class DependencyValidator
         Dictionary<string, PatchManifest> patches,
         IEnumerable<string> patchesToInstall)
     {
-        var toInstall = patchesToInstall.ToHashSet();
+        // The caller's sequence is the order the user arranged, and the sort only has to move a
+        // patch that something else depends on. Seeding from the set instead would leave the rest
+        // in whatever order it happened to enumerate.
+        var requested = patchesToInstall.ToList();
+        var toInstall = requested.ToHashSet();
         var ordered = new List<string>();
         var visited = new HashSet<string>();
 
         // Topological sort using DFS
-        foreach (var patchId in toInstall)
+        foreach (var patchId in requested)
         {
             if (!VisitPatch(patchId, patches, toInstall, visited, ordered))
             {

--- a/src/KPatchLauncher/Models/AppSettings.cs
+++ b/src/KPatchLauncher/Models/AppSettings.cs
@@ -34,6 +34,13 @@ public class AppSettings
     public List<string> CheckedPatchIds { get; set; } = new();
 
     /// <summary>
+    /// Every known patch id in the order the user arranged them, which is the order they are
+    /// installed in. Held separately from <see cref="CheckedPatchIds"/> so that unchecking a patch
+    /// does not lose its place in the list.
+    /// </summary>
+    public List<string> PatchOrder { get; set; } = new();
+
+    /// <summary>
     /// Whether to deploy through the library proxy where injection would otherwise be used.
     /// Only meaningful on Windows; Linux uses the proxy regardless.
     /// </summary>

--- a/src/KPatchLauncher/ViewModels/MainViewModel.cs
+++ b/src/KPatchLauncher/ViewModels/MainViewModel.cs
@@ -1272,7 +1272,9 @@ public class MainViewModel : ViewModelBase
                 && !string.IsNullOrWhiteSpace(GamePath)
                 && File.Exists(GamePath))
             {
-                await CheckPatchStatusAsync(GamePath, adoptInstalledAsSelection: true);
+                // Loading a patch directory is not an install, so the ticks restored above stand.
+                // A first run has nothing to keep and adopts the installed set inside the sync.
+                await CheckPatchStatusAsync(GamePath, adoptInstalledAsSelection: false);
             }
         }
         catch (Exception ex)

--- a/src/KPatchLauncher/ViewModels/MainViewModel.cs
+++ b/src/KPatchLauncher/ViewModels/MainViewModel.cs
@@ -33,6 +33,10 @@ public class MainViewModel : ViewModelBase
     private PatchItemViewModel? _selectedPatch;
     private PatchRepository? _repository;
     private readonly HashSet<string> _installedPatchIds = new(StringComparer.OrdinalIgnoreCase);
+
+    // The order the installed patches were applied in. Kept alongside the set because a reorder
+    // changes what installing would do without changing which patches are involved.
+    private readonly List<string> _installedPatchOrder = new();
     private readonly AppSettings _settings;
     private bool _hasInstalledPatches;
     private bool _isOperationInProgress;
@@ -73,8 +77,8 @@ public class MainViewModel : ViewModelBase
         RefreshCommand = new SimpleCommand(async () => await Refresh());
         ToggleIdentifyUnrecognisedBuildsCommand =
             new SimpleCommand(() => IdentifyUnrecognisedBuilds = !IdentifyUnrecognisedBuilds);
-        MoveUpCommand = new SimpleCommand(() => MoveUp());
-        MoveDownCommand = new SimpleCommand(() => MoveDown());
+        MoveUpCommand = new SimpleCommand(p => MoveUp(p as PatchItemViewModel));
+        MoveDownCommand = new SimpleCommand(p => MoveDown(p as PatchItemViewModel));
         ApplyPatchesCommand = new SimpleCommand(async () => await ApplyPatches());
         UninstallAllCommand = new SimpleCommand(async () => await UninstallAll(), () => HasInstalledPatches);
         LaunchGameCommand = new SimpleCommand(async () => await LaunchGame());
@@ -399,9 +403,37 @@ public class MainViewModel : ViewModelBase
         }
     }
 
-    public string PendingChangesMessage => PendingChangesCount == 0
-        ? "No pending changes"
-        : $"{PendingChangesCount} patch{(PendingChangesCount == 1 ? "" : "es")} pending";
+    /// <summary>
+    /// True when the same patches are installed but in a different order to the one now shown.
+    /// Applying would reinstall them in the new order, so this is a real pending change even
+    /// though <see cref="PendingChangesCount"/> is zero.
+    /// </summary>
+    public bool HasPendingReorder
+    {
+        get
+        {
+            if (PendingChangesCount != 0)
+                return false;
+
+            var desired = AllPatches
+                .Where(p => p.IsChecked && !p.IsOrphaned)
+                .Select(p => p.Id)
+                .ToList();
+
+            var current = _installedPatchOrder
+                .Where(id => AllPatches.Any(p => string.Equals(p.Id, id, StringComparison.OrdinalIgnoreCase) && !p.IsOrphaned))
+                .ToList();
+
+            return desired.Count == current.Count
+                && !desired.SequenceEqual(current, StringComparer.OrdinalIgnoreCase);
+        }
+    }
+
+    public string PendingChangesMessage => PendingChangesCount != 0
+        ? $"{PendingChangesCount} patch{(PendingChangesCount == 1 ? "" : "es")} pending"
+        : HasPendingReorder
+            ? "Load order changed"
+            : "No pending changes";
 
     public ICommand BrowseGameCommand { get; }
     public ICommand BrowseGameFolderCommand { get; }
@@ -711,34 +743,45 @@ public class MainViewModel : ViewModelBase
         OnPropertyChanged(nameof(HasVisiblePatches));
     }
 
-    private void MoveUp()
+    private void MoveUp(PatchItemViewModel? target = null) => MoveRelativeToVisibleNeighbour(target, -1);
+
+    private void MoveDown(PatchItemViewModel? target = null) => MoveRelativeToVisibleNeighbour(target, 1);
+
+    /// <summary>
+    /// Moves a patch one place up or down the list the user can actually see.
+    /// </summary>
+    /// <param name="target">
+    /// The row the button belongs to, or null when the command came from somewhere without a row,
+    /// in which case the list selection is used.
+    /// </param>
+    /// <param name="direction">-1 to move towards the top of the list, 1 towards the bottom.</param>
+    private void MoveRelativeToVisibleNeighbour(PatchItemViewModel? patch, int direction)
     {
-        if (SelectedPatch == null)
+        patch ??= SelectedPatch;
+        if (patch == null)
             return;
 
-        var patch = SelectedPatch;
-        var index = AllPatches.IndexOf(patch);
-        if (index > 0)
-        {
-            AllPatches.Move(index, index - 1);
-            StatusMessage = $"Moved {patch.Name} up";
-            UpdatePendingChanges();
-        }
-    }
-
-    private void MoveDown()
-    {
-        if (SelectedPatch == null)
+        // Step over the neighbour in VisiblePatches rather than in AllPatches. An incompatible
+        // patch sits in AllPatches but not in the list, so stepping one index there can swap the
+        // row with something the user cannot see and appear to do nothing at all.
+        var visibleIndex = VisiblePatches.IndexOf(patch);
+        var neighbourIndex = visibleIndex + direction;
+        if (visibleIndex < 0 || neighbourIndex < 0 || neighbourIndex >= VisiblePatches.Count)
             return;
 
-        var patch = SelectedPatch;
-        var index = AllPatches.IndexOf(patch);
-        if (index < AllPatches.Count - 1)
-        {
-            AllPatches.Move(index, index + 1);
-            StatusMessage = $"Moved {patch.Name} down";
-            UpdatePendingChanges();
-        }
+        var from = AllPatches.IndexOf(patch);
+        var to = AllPatches.IndexOf(VisiblePatches[neighbourIndex]);
+        if (from < 0 || to < 0)
+            return;
+
+        AllPatches.Move(from, to);
+
+        // Clicking the button does not select the row, so carry the selection across to keep the
+        // details panel on this patch and let the button be pressed repeatedly.
+        SelectedPatch = patch;
+        StatusMessage = $"Moved {patch.Name} {(direction < 0 ? "up" : "down")}";
+        SaveCheckedPatches();
+        UpdatePendingChanges();
     }
 
     private void InvalidatePatchStateForGamePathChange()
@@ -758,6 +801,7 @@ public class MainViewModel : ViewModelBase
         if (clearInstalledState)
         {
             _installedPatchIds.Clear();
+            _installedPatchOrder.Clear();
             HasInstalledPatches = false;
         }
 
@@ -794,9 +838,11 @@ public class MainViewModel : ViewModelBase
             .ToList();
 
         _installedPatchIds.Clear();
+        _installedPatchOrder.Clear();
         foreach (var patchId in normalizedInstalledIds)
         {
             _installedPatchIds.Add(patchId);
+            _installedPatchOrder.Add(patchId);
         }
 
         HasInstalledPatches = _installedPatchIds.Count > 0;
@@ -918,12 +964,14 @@ public class MainViewModel : ViewModelBase
     private void SaveCheckedPatches()
     {
         _settings.CheckedPatchIds = AllPatches.Where(p => p.IsChecked).Select(p => p.Id).ToList();
+        _settings.PatchOrder = AllPatches.Where(p => !p.IsOrphaned).Select(p => p.Id).ToList();
         _settings.Save();
     }
 
     private void UpdatePendingChanges()
     {
         OnPropertyChanged(nameof(PendingChangesCount));
+        OnPropertyChanged(nameof(HasPendingReorder));
         OnPropertyChanged(nameof(PendingChangesMessage));
     }
 
@@ -1187,6 +1235,14 @@ public class MainViewModel : ViewModelBase
 
                 // Restore checked state from settings
                 var checkedIds = _settings.CheckedPatchIds.ToHashSet();
+
+                var savedOrder = _settings.PatchOrder
+                    .Select((id, position) => (id, position))
+                    .ToDictionary(x => x.id, x => x.position, StringComparer.OrdinalIgnoreCase);
+
+                patchViewModels = patchViewModels
+                    .OrderBy(p => savedOrder.TryGetValue(p.Id, out var position) ? position : int.MaxValue)
+                    .ToList();
 
                 foreach (var patch in patchViewModels)
                 {

--- a/src/KPatchLauncher/ViewModels/MainViewModel.cs
+++ b/src/KPatchLauncher/ViewModels/MainViewModel.cs
@@ -749,7 +749,7 @@ public class MainViewModel : ViewModelBase
     /// <summary>
     /// Moves a patch one place up or down the list the user can actually see.
     /// </summary>
-    /// <param name="target">
+    /// <param name="patch">
     /// The row the button belongs to, or null when the command came from somewhere without a row,
     /// in which case the list selection is used.
     /// </param>
@@ -1245,9 +1245,13 @@ public class MainViewModel : ViewModelBase
                 // Restore checked state from settings
                 var checkedIds = _settings.CheckedPatchIds.ToHashSet();
 
-                var savedOrder = _settings.PatchOrder
-                    .Select((id, position) => (id, position))
-                    .ToDictionary(x => x.id, x => x.position, StringComparer.OrdinalIgnoreCase);
+                // TryAdd rather than ToDictionary: settings.json is editable by hand, and a
+                // repeated id would otherwise throw out of the load and leave no patches at all.
+                var savedOrder = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+                for (var position = 0; position < _settings.PatchOrder.Count; position++)
+                {
+                    savedOrder.TryAdd(_settings.PatchOrder[position], position);
+                }
 
                 patchViewModels = patchViewModels
                     .OrderBy(p => savedOrder.TryGetValue(p.Id, out var position) ? position : int.MaxValue)

--- a/src/KPatchLauncher/ViewModels/MainViewModel.cs
+++ b/src/KPatchLauncher/ViewModels/MainViewModel.cs
@@ -59,8 +59,8 @@ public class MainViewModel : ViewModelBase
         // syncs explicitly as well.
         AllPatches.CollectionChanged += (_, _) => SyncVisiblePatches();
 
-        // Load settings. Pending patch selections are intentionally not restored at startup;
-        // installed patch state is reloaded from the selected game's patch_config.toml.
+        // Load settings. The selection is restored as the user left it; a tick that does not match
+        // what is installed is a pending change, which is what the pending-changes count is for.
         _settings = AppSettings.Load();
         _gamePath = _settings.GamePath;
         _patchesPath = _settings.PatchesPath;
@@ -68,7 +68,6 @@ public class MainViewModel : ViewModelBase
         _customLaunchCommand = _settings.CustomLaunchCommand;
         DeploymentPolicy.PreferLibraryProxy = _settings.PreferLibraryProxy;
         GameDetector.IdentifyUnrecognisedBuilds = _settings.IdentifyUnrecognisedBuilds;
-        ClearPersistedPatchSelection();
 
         // Create simple commands
         BrowseGameCommand = new SimpleCommand(async () => await BrowseGame());
@@ -830,7 +829,14 @@ public class MainViewModel : ViewModelBase
         UpdatePendingChanges();
     }
 
-    private void SyncPatchSelectionWithInstalledPatches(IEnumerable<string> installedPatchIds)
+    /// <param name="adoptInstalledAsSelection">
+    /// True after installing or uninstalling, where what is on disk is the authority and the ticks
+    /// should match it. False for a plain status check, which must leave the user's pending ticks
+    /// alone; on a first run there are none to keep, so the installed set is adopted regardless.
+    /// </param>
+    private void SyncPatchSelectionWithInstalledPatches(
+        IEnumerable<string> installedPatchIds,
+        bool adoptInstalledAsSelection)
     {
         var normalizedInstalledIds = installedPatchIds
             .Where(id => !string.IsNullOrWhiteSpace(id))
@@ -848,17 +854,20 @@ public class MainViewModel : ViewModelBase
         HasInstalledPatches = _installedPatchIds.Count > 0;
         RemoveOrphanedPatches();
 
-        _isBulkUpdatingPatchChecks = true;
-        try
+        if (adoptInstalledAsSelection || _settings.CheckedPatchIds.Count == 0)
         {
-            foreach (var patch in AllPatches)
+            _isBulkUpdatingPatchChecks = true;
+            try
             {
-                patch.IsChecked = _installedPatchIds.Contains(patch.Id);
+                foreach (var patch in AllPatches)
+                {
+                    patch.IsChecked = _installedPatchIds.Contains(patch.Id);
+                }
             }
-        }
-        finally
-        {
-            _isBulkUpdatingPatchChecks = false;
+            finally
+            {
+                _isBulkUpdatingPatchChecks = false;
+            }
         }
 
         foreach (var patchId in normalizedInstalledIds)
@@ -1021,7 +1030,7 @@ public class MainViewModel : ViewModelBase
                 {
                     if (uninstallResult.Success)
                     {
-                        SyncPatchSelectionWithInstalledPatches(Array.Empty<string>());
+                        SyncPatchSelectionWithInstalledPatches(Array.Empty<string>(), adoptInstalledAsSelection: true);
                         SetOperationInProgress(false, "All patches uninstalled successfully");
                     }
                     else
@@ -1069,7 +1078,7 @@ public class MainViewModel : ViewModelBase
             });
 
             // Refresh installed status
-            await CheckPatchStatusAsync(GamePath);
+            await CheckPatchStatusAsync(GamePath, adoptInstalledAsSelection: true);
         }
         catch (Exception ex)
         {
@@ -1263,7 +1272,7 @@ public class MainViewModel : ViewModelBase
                 && !string.IsNullOrWhiteSpace(GamePath)
                 && File.Exists(GamePath))
             {
-                await CheckPatchStatusAsync(GamePath);
+                await CheckPatchStatusAsync(GamePath, adoptInstalledAsSelection: true);
             }
         }
         catch (Exception ex)
@@ -1278,7 +1287,10 @@ public class MainViewModel : ViewModelBase
         }
     }
 
-    private async Task CheckPatchStatusAsync(string gameExePath, bool isAutoRefresh = true)
+    private async Task CheckPatchStatusAsync(
+        string gameExePath,
+        bool isAutoRefresh = true,
+        bool adoptInstalledAsSelection = false)
     {
         if (_repository == null)
             return;
@@ -1309,13 +1321,13 @@ public class MainViewModel : ViewModelBase
 
                 if (!installInfo.Success || installInfo.Data == null)
                 {
-                    SyncPatchSelectionWithInstalledPatches(Array.Empty<string>());
+                    SyncPatchSelectionWithInstalledPatches(Array.Empty<string>(), adoptInstalledAsSelection);
                     SetOperationInProgress(false, isAutoRefresh ? null : "No patches detected", isAutoRefresh);
                     return;
                 }
 
                 var info = installInfo.Data;
-                SyncPatchSelectionWithInstalledPatches(info.InstalledPatches);
+                SyncPatchSelectionWithInstalledPatches(info.InstalledPatches, adoptInstalledAsSelection);
 
                 var installedCount = _installedPatchIds.Count;
                 SetOperationInProgress(
@@ -1336,7 +1348,9 @@ public class MainViewModel : ViewModelBase
                 if (!IsPatchStatusRequestCurrent(requestVersion, gameExePath))
                     return;
 
-                SyncPatchSelectionWithInstalledPatches(Array.Empty<string>());
+                // Failing to read the status says nothing about what the user selected, so the
+                // caller's authority still decides whether the ticks are rewritten.
+                SyncPatchSelectionWithInstalledPatches(Array.Empty<string>(), adoptInstalledAsSelection);
                 SetOperationInProgress(false, isAutoRefresh ? null : $"Could not check patch status: {ex.Message}", isAutoRefresh);
             });
         }

--- a/src/KPatchLauncher/ViewModels/SimpleCommand.cs
+++ b/src/KPatchLauncher/ViewModels/SimpleCommand.cs
@@ -24,7 +24,8 @@ public class SimpleCommand : ICommand
     /// </summary>
     public SimpleCommand(Action<object?> execute, Func<bool>? canExecute = null)
     {
-        _execute = execute ?? throw new ArgumentNullException(nameof(execute));
+        ArgumentNullException.ThrowIfNull(execute);
+        _execute = execute;
         _canExecute = canExecute;
     }
 

--- a/src/KPatchLauncher/ViewModels/SimpleCommand.cs
+++ b/src/KPatchLauncher/ViewModels/SimpleCommand.cs
@@ -8,10 +8,21 @@ namespace KPatchLauncher.ViewModels;
 /// </summary>
 public class SimpleCommand : ICommand
 {
-    private readonly Action _execute;
+    private readonly Action<object?> _execute;
     private readonly Func<bool>? _canExecute;
 
     public SimpleCommand(Action execute, Func<bool>? canExecute = null)
+    {
+        ArgumentNullException.ThrowIfNull(execute);
+        _execute = _ => execute();
+        _canExecute = canExecute;
+    }
+
+    /// <summary>
+    /// For commands bound inside an item template, where the command needs to act on the row that
+    /// was clicked rather than on the list's current selection.
+    /// </summary>
+    public SimpleCommand(Action<object?> execute, Func<bool>? canExecute = null)
     {
         _execute = execute ?? throw new ArgumentNullException(nameof(execute));
         _canExecute = canExecute;
@@ -28,7 +39,7 @@ public class SimpleCommand : ICommand
     {
         if (CanExecute(parameter))
         {
-            _execute();
+            _execute(parameter);
         }
     }
 

--- a/src/KPatchLauncher/Views/MainWindow.axaml
+++ b/src/KPatchLauncher/Views/MainWindow.axaml
@@ -296,6 +296,7 @@
                                                     Margin="8,0,0,0">
                                             <Button Content="↑"
                                                     Command="{Binding $parent[Window].DataContext.MoveUpCommand}"
+                                                    CommandParameter="{Binding}"
                                                     Width="24"
                                                     Height="24"
                                                     Padding="0"
@@ -303,6 +304,7 @@
                                                     ToolTip.Tip="Move Up"/>
                                             <Button Content="↓"
                                                     Command="{Binding $parent[Window].DataContext.MoveDownCommand}"
+                                                    CommandParameter="{Binding}"
                                                     Width="24"
                                                     Height="24"
                                                     Padding="0"


### PR DESCRIPTION
The patch list's reorder buttons didn't seem to work

A couple of separate bugs, all in the launcher UI layer.

**Reorder buttons did nothing.** They sit in the list's item template but acted on `SelectedPatch`. A `Button` inside a `ListBoxItem` marks the pointer event handled, so clicking one never selects its row; with nothing selected the command returned immediately. They now receive their row as a `CommandParameter`.

**Moves could be invisible.** The step was taken one index through `AllPatches`, which contains incompatible patches the list doesn't display, so a move could swap a row past something unseen and appear to do nothing. The step is now taken over the neighbour in `VisiblePatches`.

**Load order was lost on restart.** The order decides the order patches are installed in, but was only held in memory. The saved list was read back as a `HashSet`. It's now persisted and reapplied on load, with patches it doesn't mention appended in their natural order.

**Checked patches were lost on restart.** The constructor cleared the saved selection at startup, and the status check then rewrote every tick to match what was installed. The selection is now restored, and the installed set only overwrites it when it's the authority: after installing or uninstalling, or on a first run with nothing saved. A failed status *read* no longer discards the selection either.

Also: a pure reorder previously reported "No pending changes", because the count compares ids alphabetically and a reorder changes neither set. It now reads "Load order changed".

### Where the settings live

`settings.json`, under `Environment.SpecialFolder.ApplicationData`:

| Platform | Path |
|---|---|
| Linux | `~/.config/KPatchLauncher/settings.json` |
| macOS | `~/Library/Application Support/KPatchLauncher/settings.json` |
| Windows | `%APPDATA%\KPatchLauncher\settings.json` |

Two keys carry this state, kept separate so unchecking a patch doesn't lose its place in the list:

- `PatchOrder`: every known patch id in list order
- `CheckedPatchIds`: only the ticked ones

Existing settings files load unchanged; `PatchOrder` defaults to empty, which yields the current natural ordering.